### PR TITLE
Feature/add brick v1 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ chw_flow_sensor.type_docs() # 'Sensor which measures the volumetric flow of chil
 chw_flow_sensor.type_uri() # 'https://project-haystack.org/def/phIoT/3.9.10#chilled-water-flow-sensor'
 
 # Generate an id for the point and bind it to a namespace
-chw_flow_sensor.gen_uuid() # UUID('2733f091-be5b-4983-b701-b7e42c52b72c')
+chw_flow_sensor.set_id() # UUID('2733f091-be5b-4983-b701-b7e42c52b72c')
 chw_flow_sensor.set_namespace(EX) # True
 
 # Add the entity to the graph hg

--- a/tasty/constants.py
+++ b/tasty/constants.py
@@ -16,15 +16,22 @@ V3_9_10 = '3.9.10'
 # Brick relevant constants
 BRICK = 'Brick'
 V1_1 = '1.1'
+V1_2 = '1.2'
 
 # Standard namespaces
 XML = Namespace("http://www.w3.org/1998/namespace#")
 XMLS = Namespace("http://www.w3.org/2001/XMLSchema#")
 
 # Define versioned Brick Namespaces
+# 1.1.0
 BRICK_1_1 = Namespace("https://brickschema.org/schema/1.1/Brick#")
 TAG_1_1 = Namespace("https://brickschema.org/schema/1.1/BrickTag#")
 BSH_1_1 = Namespace("https://brickschema.org/schema/1.1/BrickShape#")
+
+# 1.2.0
+BRICK_1_2 = Namespace("https://brickschema.org/schema/Brick#")
+TAG_1_2 = Namespace("https://brickschema.org/schema/BrickTag#")
+BSH_1_2 = Namespace("https://brickschema.org/schema/BrickShape#")
 
 # Define versioned Haystack Namespaces
 # 3.9.9
@@ -55,7 +62,7 @@ TAG_DEFAULT = None
 BSH_DEFAULT = None
 
 SUPPORTED_SCHEMAS = {
-    BRICK: [V1_1],
+    BRICK: [V1_1, V1_2],
     HAYSTACK: [V3_9_9, V3_9_10]
 }
 

--- a/tasty/graphs.py
+++ b/tasty/graphs.py
@@ -56,6 +56,10 @@ def bind_versioned_prefixes(graph: Graph, schema: str, version: str) -> None:
             graph.bind("brick", tc.BRICK_1_1)
             graph.bind("tag", tc.TAG_1_1)
             graph.bind("bsh", tc.BSH_1_1)
+        elif version == tc.V1_2:
+            graph.bind("brick", tc.BRICK_1_2)
+            graph.bind("tag", tc.TAG_1_2)
+            graph.bind("bsh", tc.BSH_1_2)
     elif schema == tc.HAYSTACK:
         if version == tc.V3_9_9:
             graph.bind("ph", tc.PH_3_9_9)
@@ -166,41 +170,41 @@ def graph_to_hayson_string(graph: Graph) -> str:
             uri_fragment_list = key.split("#")
             if key == "@id":
                 dis = val
-                json_ld_dict .update({"dis": dis})
+                json_ld_dict.update({"dis": dis})
             elif key == "@type":
                 tags = val[0].split('#')[1]
                 multitag = tags.split("-")
-                [json_ld_dict .update({tag: "m"}) for tag in multitag]
+                [json_ld_dict.update({tag: "m"}) for tag in multitag]
             elif uri_fragment_list[1] == "hasTag":
                 for tag1 in val:
                     for k, v in tag1.items():
                         if k == "@id":
                             t = v.split("#")[1]
-                            json_ld_dict .update({t: ":m"})
+                            json_ld_dict.update({t: ":m"})
             elif uri_fragment_list[1] == "equipRef":
                 for ref in val:
                     for k, v in ref.items():
                         if k == "@id":
                             t = v.split("/")[1]
-                            json_ld_dict .update({"equipRef": v})
+                            json_ld_dict.update({"equipRef": v})
             elif uri_fragment_list[1] == "condenserWaterRef":
                 for ref in val:
                     for k, v in ref.items():
                         if k == "@id":
                             t = v.split("/")[1]
-                            json_ld_dict .update({"condenserWaterRef": v})
+                            json_ld_dict.update({"condenserWaterRef": v})
             elif uri_fragment_list[1] == "hotWaterRef":
                 for ref in val:
                     for k, v in ref.items():
                         if k == "@id":
                             t = v.split("/")[1]
-                            json_ld_dict .update({"hotWaterRef": v})
+                            json_ld_dict.update({"hotWaterRef": v})
             elif uri_fragment_list[1] == "airRef":
                 for ref in val:
                     for k, v in ref.items():
                         if k == "@id":
                             t = v.split("/")[1]
-                            json_ld_dict .update({"airRef": v})
+                            json_ld_dict.update({"airRef": v})
 
             hayson_dict["rows"].append(json_ld_dict)
 

--- a/tasty/schemas/brick/Brick_1_2.ttl
+++ b/tasty/schemas/brick/Brick_1_2.ttl
@@ -1,0 +1,15544 @@
+@prefix brick: <https://brickschema.org/schema/Brick#> .
+@prefix dcterms: <http://purl.org/dc/terms#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix qudt: <http://qudt.org/schema/qudt/> .
+@prefix qudtqk: <http://qudt.org/vocab/quantitykind/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sdo: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix sosa: <http://www.w3.org/ns/sosa#> .
+@prefix tag: <https://brickschema.org/schema/BrickTag#> .
+@prefix unit: <http://qudt.org/vocab/unit/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+brick: a owl:Ontology ;
+    rdfs:label "Brick" ;
+    dcterms:creator ( [ a sdo:Person ;
+                sdo:email "gtfierro@cs.berkeley.edu" ;
+                sdo:name "Gabe Fierro" ] [ a sdo:Person ;
+                sdo:email "jbkoh@eng.ucsd.edu" ;
+                sdo:name "Jason Koh" ] ) ;
+    dcterms:license <https://github.com/BrickSchema/brick/blob/master/LICENSE> ;
+    dcterms:version "1.2.0" ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/1.2/Brick> ;
+    rdfs:seeAlso <https://brickschema.org> .
+
+brick:Ablutions_Room a owl:Class ;
+    rdfs:label "Ablutions Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Ablutions ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A room for performing cleansing rituals before prayer"@en ;
+    brick:hasAssociatedTag tag:Ablutions,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Absolute_Humidity a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Absolute Humidity" ;
+    qudt:applicableUnit unit:UNITLESS ;
+    owl:sameAs qudtqk:AbsoluteHumidity ;
+    skos:broader brick:Humidity .
+
+brick:Absorption_Chiller a owl:Class ;
+    rdfs:label "Absorption Chiller" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller [ a owl:Restriction ;
+                        owl:hasValue tag:Absorption ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Chiller ;
+    skos:definition "A chiller that utilizes a thermal or/and chemical process to produce the refrigeration effect necessary to provide chilled water. There is no mechanical compression of the refrigerant taking place within the machine, as occurs within more traditional vapor compression type chillers."@en ;
+    brick:hasAssociatedTag tag:Absorption,
+        tag:Chiller,
+        tag:Equipment .
+
+brick:Acceleration_Time a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Acceleration Time" ;
+    skos:broader brick:Time .
+
+brick:Acceleration_Time_Setpoint a owl:Class ;
+    rdfs:label "Acceleration Time Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Time _:has_Setpoint [ a owl:Restriction ;
+                        owl:hasValue tag:Acceleration ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Time_Setpoint ;
+    brick:hasAssociatedTag tag:Acceleration,
+        tag:Point,
+        tag:Setpoint,
+        tag:Time .
+
+brick:Access_Reader a owl:Class ;
+    rdfs:label "Access Reader" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Security _:has_Access [ a owl:Restriction ;
+                        owl:hasValue tag:Reader ;
+                        owl:onProperty brick:hasTag ] _:has_Control ) ],
+        brick:Access_Control_Equipment ;
+    brick:hasAssociatedTag tag:Access,
+        tag:Control,
+        tag:Equipment,
+        tag:Reader,
+        tag:Security .
+
+brick:Active_Energy a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Active Energy",
+        "Active_Energy" ;
+    qudt:applicableUnit unit:KiloW-HR,
+        unit:MegaW-HR,
+        unit:W-HR ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Electric_Energy ;
+    skos:definition "The integral of the active power over a time interval" .
+
+brick:Active_Power_Sensor a owl:Class ;
+    rdfs:label "Active Power Sensor" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/AC_power#Active,_reactive,_and_apparent_power> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power [ a owl:Restriction ;
+                        owl:hasValue tag:Real ;
+                        owl:onProperty brick:hasTag ] _:has_Electrical ) ],
+        brick:Electrical_Power_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Active_Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the portion of power that, averaged over a complete cycle of the AC waveform, results in net transfer of energy in one direction"@en ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Point,
+        tag:Power,
+        tag:Real,
+        tag:Sensor .
+
+brick:Air_Flow_Loss_Alarm a owl:Class ;
+    rdfs:label "Air Flow Loss Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Alarm _:has_Flow _:has_Loss ) ],
+        brick:Air_Alarm ;
+    skos:definition "An alarm that indicates loss in air flow."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Flow,
+        tag:Loss,
+        tag:Point .
+
+brick:Alarm_Delay_Parameter a owl:Class ;
+    rdfs:label "Alarm Delay Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Alarm _:has_Delay _:has_Parameter ) ],
+        brick:Delay_Parameter ;
+    skos:definition "A parameter determining how long to delay an alarm after sufficient conditions have been met"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Delay,
+        tag:Parameter,
+        tag:Point .
+
+brick:Alternating_Current_Frequency a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Alternating Current Frequency",
+        "Alternating_Current_Frequency" ;
+    qudt:applicableUnit unit:GigaHZ,
+        unit:HZ,
+        unit:KiloHZ,
+        unit:MegaHZ ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T-1D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Frequency,
+        brick:Frequency ;
+    skos:definition "The frequency of the oscillations of alternating current",
+        "The frequency of the oscillations of alternating current"@en ;
+    skos:related brick:Electric_Current .
+
+brick:Apparent_Energy a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Apparent Energy",
+        "Apparent_Energy" ;
+    qudt:applicableUnit unit:KiloV-A-HR ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Electric_Energy ;
+    skos:definition "The integral of the apparent power over a time interval" .
+
+brick:Apparent_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Apparent Power" ;
+    owl:sameAs qudtqk:ApparentPower ;
+    skos:broader brick:Electric_Power ;
+    skos:definition "Apparent Power is the product of the rms voltage (U) between the terminals of a two-terminal element or two-terminal circuit and the rms electric current I in the element or circuit. Under sinusoidal conditions, the apparent power is the modulus of the complex power."@en .
+
+brick:Atmospheric_Pressure a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Atmospheric Pressure" ;
+    owl:sameAs qudtqk:AtmosphericPressure ;
+    skos:broader brick:Pressure ;
+    skos:definition "The pressure exerted by the weight of the air above it at any point on the earth's surface. At sea level the atmosphere will support a column of mercury about (760 mm) high. This decreases with increasing altitude. The standard value for the atmospheric pressure at sea level in SI units is (101,325 pascals)."@en .
+
+brick:Auditorium a owl:Class ;
+    rdfs:label "Auditorium" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Auditorium ;
+                        owl:onProperty brick:hasTag ] _:has_Common _:has_Space _:has_Location ) ],
+        brick:Common_Space ;
+    skos:definition "A space for performances or larger gatherings"@en ;
+    brick:hasAssociatedTag tag:Auditorium,
+        tag:Common,
+        tag:Location,
+        tag:Space .
+
+brick:Automatic_Mode_Command a owl:Class ;
+    rdfs:label "Automatic Mode Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Automatic ;
+                        owl:onProperty brick:hasTag ] _:has_Mode _:has_Command ) ],
+        brick:Mode_Command ;
+    skos:definition "Controls whether or not a device or controller is operating in \"Automatic\" mode"@en ;
+    brick:hasAssociatedTag tag:Automatic,
+        tag:Command,
+        tag:Mode,
+        tag:Point .
+
+brick:Average_Cooling_Demand_Sensor a owl:Class ;
+    rdfs:label "Average Cooling Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Demand _:has_Cool _:has_Average ) ],
+        brick:Cooling_Demand_Sensor ;
+    skos:definition "Measures the average power consumed by a cooling process as the amount of power consumed over some interval"@en ;
+    brick:hasAssociatedTag tag:Average,
+        tag:Cool,
+        tag:Demand,
+        tag:Point,
+        tag:Sensor .
+
+brick:Average_Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
+    rdfs:label "Average Exhaust Air Static Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Average _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
+        brick:Exhaust_Air_Static_Pressure_Sensor ;
+    skos:definition "The computed average static pressure of air in exhaust regions of an HVAC system over some period of time"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Average,
+        tag:Exhaust,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Static .
+
+brick:Average_Heating_Demand_Sensor a owl:Class ;
+    rdfs:label "Average Heating Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Demand _:has_Heat _:has_Average ) ],
+        brick:Heating_Demand_Sensor ;
+    skos:definition "Measures the average power consumed by a heating process as the amount of power consumed over some interval"@en ;
+    brick:hasAssociatedTag tag:Average,
+        tag:Demand,
+        tag:Heat,
+        tag:Point,
+        tag:Sensor .
+
+brick:Average_Supply_Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Average Supply Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Average _:has_Supply _:has_Air _:has_Flow _:has_Sensor ) ],
+        brick:Supply_Air_Flow_Sensor ;
+    owl:equivalentClass brick:Average_Discharge_Air_Flow_Sensor ;
+    skos:definition "The computed average flow of supply air over some interval"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Average,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply .
+
+brick:Average_Zone_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Average Zone Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Zone _:has_Average _:has_Air ) ],
+        brick:Zone_Air_Temperature_Sensor ;
+    skos:definition "The computed average temperature of air in a zone, over some period of time"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Average,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Zone .
+
+brick:Basement a owl:Class ;
+    rdfs:label "Basement" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Basement ;
+                        owl:onProperty brick:hasTag ] _:has_Location _:has_Floor ) ],
+        brick:Floor ;
+    skos:definition "The floor of a building which is partly or entirely below ground level."@en ;
+    brick:hasAssociatedTag tag:Basement,
+        tag:Floor,
+        tag:Location .
+
+brick:Battery a owl:Class ;
+    rdfs:label "Battery" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Battery _:has_Energy _:has_Storage _:has_Equipment ) ],
+        brick:Energy_Storage ;
+    skos:definition "A container that stores chemical energy that can be converted into electricity and used as a source of power"@en ;
+    brick:hasAssociatedTag tag:Battery,
+        tag:Energy,
+        tag:Equipment,
+        tag:Storage .
+
+brick:Battery_Room a owl:Class ;
+    rdfs:label "Battery Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Battery _:has_Electrical _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Electrical_Room ;
+    skos:definition "A room used to hold batteries for backup power"@en ;
+    brick:hasAssociatedTag tag:Battery,
+        tag:Electrical,
+        tag:Location,
+        tag:Room,
+        tag:Service,
+        tag:Space .
+
+brick:Battery_Voltage_Sensor a owl:Class ;
+    rdfs:label "Battery Voltage Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Voltage _:has_Battery ) ],
+        brick:Voltage_Sensor ;
+    skos:definition "Measures the capacity of a battery"@en ;
+    brick:hasAssociatedTag tag:Battery,
+        tag:Point,
+        tag:Sensor,
+        tag:Voltage .
+
+brick:Bench_Space a owl:Class ;
+    rdfs:label "Bench Space" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Location _:has_Outdoor _:has_Area [ a owl:Restriction ;
+                        owl:hasValue tag:Bench ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Outdoor_Area ;
+    skos:definition "For areas of play in a stadium, the area for partcipants and referees by the side of the field"@en ;
+    brick:hasAssociatedTag tag:Area,
+        tag:Bench,
+        tag:Location,
+        tag:Outdoor .
+
+brick:Boiler a owl:Class ;
+    rdfs:label "Boiler" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Boiler ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC_Equipment,
+        brick:Water_Heater ;
+    skos:definition "A closed, pressure vessel that uses fuel or electricity for heating water or other fluids to supply steam or hot water for heating, humidification, or other applications."@en ;
+    brick:hasAssociatedTag tag:Boiler,
+        tag:Equipment .
+
+brick:Booster_Fan a owl:Class ;
+    rdfs:label "Booster Fan" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan [ a owl:Restriction ;
+                        owl:hasValue tag:Booster ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Fan ;
+    skos:definition "Fan activated to increase airflow beyond what is provided by the default configuration"@en ;
+    brick:hasAssociatedTag tag:Booster,
+        tag:Equipment,
+        tag:Fan .
+
+brick:Box_Mode_Command a owl:Class ;
+    rdfs:label "Box Mode Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Box _:has_Mode _:has_Command ) ],
+        brick:Mode_Command ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Command,
+        tag:Mode,
+        tag:Point .
+
+brick:Breaker_Panel a owl:Class ;
+    rdfs:label "Breaker Panel" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Breaker ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Electrical_Equipment ;
+    skos:definition "Breaker Panel distributes power into various end-uses."@en ;
+    brick:hasAssociatedTag tag:Breaker,
+        tag:Equipment .
+
+brick:Broadcast_Room a owl:Class ;
+    rdfs:label "Broadcast Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Broadcast ;
+                        owl:onProperty brick:hasTag ] _:has_Media _:has_Room _:has_Space _:has_Location ) ],
+        brick:Media_Room ;
+    skos:definition "A space to organize and manage a broadcast. Separate from studio"@en ;
+    brick:hasAssociatedTag tag:Broadcast,
+        tag:Location,
+        tag:Media,
+        tag:Room,
+        tag:Space .
+
+brick:Building_Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Building Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air _:has_Building ) ],
+        brick:Air_Humidity_Setpoint ;
+    skos:definition "Setpoint for humidity in a building"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Building,
+        tag:Humidity,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Building_Air_Static_Pressure_Sensor a owl:Class ;
+    rdfs:label "Building Air Static Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
+        brick:Static_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Static_Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Building_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "The static pressure of air within a building"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Building,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Static .
+
+brick:Building_Air_Static_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Building Air Static Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Building _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+        brick:Static_Pressure_Setpoint ;
+    skos:definition "Sets static pressure of the entire building"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Building,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Building_Chilled_Water_Meter a owl:Class ;
+    rdfs:label "Building Chilled Water Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Chilled _:has_Water _:has_Meter _:has_Equipment ) ],
+        brick:Building_Meter,
+        brick:Chilled_Water_Meter ;
+    skos:definition "A meter that measures the usage or consumption of chilled water of a whole building"@en ;
+    brick:hasAssociatedTag tag:Building,
+        tag:Chilled,
+        tag:Equipment,
+        tag:Meter,
+        tag:Water .
+
+brick:Building_Electrical_Meter a owl:Class ;
+    rdfs:label "Building Electrical Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Electrical _:has_Meter _:has_Equipment ) ],
+        brick:Building_Meter,
+        brick:Electrical_Meter ;
+    skos:definition "A meter that measures the usage or consumption of electricity of a whole building"@en ;
+    brick:hasAssociatedTag tag:Building,
+        tag:Electrical,
+        tag:Equipment,
+        tag:Meter .
+
+brick:Building_Gas_Meter a owl:Class ;
+    rdfs:label "Building Gas Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Gas _:has_Meter _:has_Equipment ) ],
+        brick:Building_Meter,
+        brick:Gas_Meter ;
+    skos:definition "A meter that measures the usage or consumption of gas of a whole building"@en ;
+    brick:hasAssociatedTag tag:Building,
+        tag:Equipment,
+        tag:Gas,
+        tag:Meter .
+
+brick:Building_Hot_Water_Meter a owl:Class ;
+    rdfs:label "Building Hot Water Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Hot _:has_Water _:has_Meter _:has_Equipment ) ],
+        brick:Building_Meter,
+        brick:Hot_Water_Meter ;
+    skos:definition "A meter that measures the usage or consumption of hot water of a whole building"@en ;
+    brick:hasAssociatedTag tag:Building,
+        tag:Equipment,
+        tag:Hot,
+        tag:Meter,
+        tag:Water .
+
+brick:Building_Water_Meter a owl:Class ;
+    rdfs:label "Building Water Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Water _:has_Meter _:has_Equipment ) ],
+        brick:Building_Meter,
+        brick:Water_Meter ;
+    skos:definition "A meter that measures the usage or consumption of water of a whole building"@en ;
+    brick:hasAssociatedTag tag:Building,
+        tag:Equipment,
+        tag:Meter,
+        tag:Water .
+
+brick:Bus_Riser a owl:Class ;
+    rdfs:label "Bus Riser" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Riser _:has_Equipment ) ],
+        brick:Electrical_Equipment ;
+    skos:definition "Bus Risers are commonly fed from a switchgear and rise up through a series of floors to the main power distribution source for each floor."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Riser .
+
+brick:Bypass_Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Bypass Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Bypass ) ],
+        brick:Air_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Bypass_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of bypass air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Bypass,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor .
+
+brick:Bypass_Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Bypass Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air _:has_Bypass ) ],
+        brick:Air_Humidity_Setpoint ;
+    skos:definition "Humidity setpoint for bypass air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Bypass,
+        tag:Humidity,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Bypass_Command a owl:Class ;
+    rdfs:label "Bypass Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Bypass _:has_Command ) ],
+        brick:Command ;
+    brick:hasAssociatedTag tag:Bypass,
+        tag:Command,
+        tag:Point .
+
+brick:CO2_Concentration a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "CO2 Concentration",
+        "CO2Concentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration of CO2 in air" .
+
+brick:CO2_Differential_Sensor a owl:Class ;
+    rdfs:label "CO2 Differential Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Differential _:has_Sensor ) ],
+        brick:CO2_Sensor ;
+    skos:definition "Measures the difference between CO2 levels of inside and outside air"@en ;
+    brick:hasAssociatedTag tag:CO2,
+        tag:Differential,
+        tag:Point,
+        tag:Sensor .
+
+brick:CO2_Level_Sensor a owl:Class ;
+    rdfs:label "CO2 Level Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Level _:has_Sensor ) ],
+        brick:CO2_Sensor ;
+    skos:definition "Measures the concentration of CO2"@en ;
+    brick:hasAssociatedTag tag:CO2,
+        tag:Level,
+        tag:Point,
+        tag:Sensor .
+
+brick:CO_Concentration a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "CO Concentration",
+        "COConcentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration of CO in air" .
+
+brick:CO_Differential_Sensor a owl:Class ;
+    rdfs:label "CO Differential Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO _:has_Differential _:has_Sensor ) ],
+        brick:CO_Sensor ;
+    brick:hasAssociatedTag tag:CO,
+        tag:Differential,
+        tag:Point,
+        tag:Sensor .
+
+brick:CO_Level_Sensor a owl:Class ;
+    rdfs:label "CO Level Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO _:has_Level _:has_Sensor ) ],
+        brick:CO_Sensor ;
+    skos:definition "Measures the concentration of CO"@en ;
+    brick:hasAssociatedTag tag:CO,
+        tag:Level,
+        tag:Point,
+        tag:Sensor .
+
+brick:Cafeteria a owl:Class ;
+    rdfs:label "Cafeteria" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Cafeteria ;
+                        owl:onProperty brick:hasTag ] _:has_Common _:has_Space _:has_Location ) ],
+        brick:Common_Space ;
+    skos:definition "A space to serve food and beverages"@en ;
+    brick:hasAssociatedTag tag:Cafeteria,
+        tag:Common,
+        tag:Location,
+        tag:Space .
+
+brick:Capacity_Sensor a owl:Class ;
+    rdfs:label "Capacity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
+                        owl:hasValue tag:Capacity ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Capacity ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Capacity,
+        tag:Point,
+        tag:Sensor .
+
+brick:Ceiling_Fan a owl:Class ;
+    rdfs:label "Ceiling Fan" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan [ a owl:Restriction ;
+                        owl:hasValue tag:Ceiling ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Fan ;
+    skos:definition "A fan installed on the ceiling of a room for the purpose of air circulation"@en ;
+    brick:hasAssociatedTag tag:Ceiling,
+        tag:Equipment,
+        tag:Fan .
+
+brick:Centrifugal_Chiller a owl:Class ;
+    rdfs:label "Centrifugal Chiller" ;
+    rdfs:seeAlso <https://bellomyims.com/your-definitive-guide-to-centrifugal-chillers/> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller [ a owl:Restriction ;
+                        owl:hasValue tag:Centrifugal ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Chiller ;
+    skos:definition "A chiller that uses the vapor compression cycle to chill water. It throws off the heat collected from the chilled water plus the heat from the compressor to a water loop"@en ;
+    brick:hasAssociatedTag tag:Centrifugal,
+        tag:Chiller,
+        tag:Equipment .
+
+brick:Change_Filter_Alarm a owl:Class ;
+    rdfs:label "Change Filter Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Change ;
+                        owl:onProperty brick:hasTag ] _:has_Filter _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates that a filter must be changed"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Change,
+        tag:Filter,
+        tag:Point .
+
+brick:Chilled_Water_Coil a owl:Class ;
+    rdfs:label "Chilled Water Coil" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Coil _:has_Cool _:has_Water ) ],
+        brick:Cooling_Coil ;
+    skos:definition "A cooling element made of pipe or tube that removes heat from equipment, machines or airflows that is filled with chilled water."@en ;
+    brick:hasAssociatedTag tag:Coil,
+        tag:Cool,
+        tag:Equipment,
+        tag:Water .
+
+brick:Chilled_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Chilled Water Differential Pressure Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Differential_Pressure_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Time,
+        tag:Water .
+
+brick:Chilled_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
+    rdfs:label "Chilled Water Differential Pressure Load Shed Reset Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+        brick:Chilled_Water_Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Load,
+        tag:Point,
+        tag:Pressure,
+        tag:Reset,
+        tag:Shed,
+        tag:Status,
+        tag:Water .
+
+brick:Chilled_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
+    rdfs:label "Chilled Water Differential Pressure Load Shed Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Setpoint ) ],
+        brick:Chilled_Water_Differential_Pressure_Setpoint,
+        brick:Load_Shed_Differential_Pressure_Setpoint ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Load,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Shed,
+        tag:Water .
+
+brick:Chilled_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Chilled Water Differential Pressure Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Differential_Pressure_Proportional_Band ;
+    brick:hasAssociatedTag tag:Band,
+        tag:Chilled,
+        tag:Differential,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Proportional,
+        tag:Water .
+
+brick:Chilled_Water_Differential_Pressure_Sensor a owl:Class ;
+    rdfs:label "Chilled Water Differential Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Chilled ) ],
+        brick:Differential_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Chilled_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the difference in water pressure on either side of a chilled water valve"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Water .
+
+brick:Chilled_Water_Differential_Pressure_Step_Parameter a owl:Class ;
+    rdfs:label "Chilled Water Differential Pressure Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
+        brick:Differential_Pressure_Step_Parameter ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Step,
+        tag:Water .
+
+brick:Chilled_Water_Differential_Temperature_Sensor a owl:Class ;
+    rdfs:label "Chilled Water Differential Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Temperature _:has_Sensor ) ],
+        brick:Chilled_Water_Temperature_Sensor ;
+    skos:definition "Measures the difference in temperature between return water (to the cooling tower) and supply water (from the chiller)"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Chilled_Water_Pump a owl:Class ;
+    rdfs:label "Chilled Water Pump" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Chilled _:has_Water ) ],
+        brick:Water_Pump ;
+    skos:definition "A pump that performs work on chilled water; typically part of a chilled water system"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Equipment,
+        tag:Pump,
+        tag:Water .
+
+brick:Chilled_Water_Pump_Differential_Pressure_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Chilled Water Pump Differential Pressure Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Pump _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+        brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of differential pressure of chilled water in a chilled water pump"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Deadband,
+        tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Pump,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Chilled_Water_Return_Temperature_Sensor a owl:Class ;
+    rdfs:label "Chilled Water Return Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+        brick:Chilled_Water_Temperature_Sensor,
+        brick:Return_Water_Temperature_Sensor ;
+    skos:definition "Measures the temperature of chilled water that is returned to a cooling tower"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Chilled_Water_Static_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Chilled Water Static Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
+        brick:Static_Pressure_Setpoint ;
+    skos:definition "Sets static pressure of chilled water"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static,
+        tag:Water .
+
+brick:Chilled_Water_Supply_Flow_Sensor a owl:Class ;
+    rdfs:label "Chilled Water Supply Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Supply _:has_Chilled ) ],
+        brick:Supply_Water_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Chilled_Water ;
+                        owl:onProperty brick:measures ] ) ],
+        brick:Chilled_Water_Discharge_Flow_Sensor ;
+    skos:definition "Measures the rate of flow of chilled supply water"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Water .
+
+brick:Chilled_Water_Supply_Temperature_Sensor a owl:Class ;
+    rdfs:label "Chilled Water Supply Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled _:has_Supply ) ],
+        brick:Chilled_Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Chilled_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of chilled water that is supplied from a chiller"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Chilled_Water_System a owl:Class ;
+    rdfs:label "Chilled Water System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Chilled _:has_System ) ],
+        brick:Water_System ;
+    skos:definition "The equipment, devices and conduits that handle the production and distribution of chilled water in a building"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:System,
+        tag:Water .
+
+brick:Chilled_Water_System_Enable_Command a owl:Class ;
+    rdfs:label "Chilled Water System Enable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Chilled _:has_Water _:has_System ) ],
+        brick:System_Enable_Command ;
+    skos:definition "Enables operation of the chilled water system"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Command,
+        tag:Enable,
+        tag:Point,
+        tag:System,
+        tag:Water .
+
+brick:Chilled_Water_Valve a owl:Class ;
+    rdfs:label "Chilled Water Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Chilled _:has_Valve _:has_Water _:has_Equipment ) ],
+        brick:Water_Valve ;
+    skos:definition "A valve that modulates the flow of chilled water"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Equipment,
+        tag:Valve,
+        tag:Water .
+
+brick:Close_Limit a owl:Class ;
+    rdfs:label "Close Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Close ;
+                        owl:onProperty brick:hasTag ] _:has_Parameter _:has_Limit ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Close_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Close,
+        tag:Limit,
+        tag:Parameter,
+        tag:Point .
+
+brick:Cloudage a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Cloudage" ;
+    qudt:applicableUnit unit:Okta ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless ;
+    skos:definition "The fraction of the sky obscured by clouds when observed from a particular location",
+        "The fraction of the sky obscured by clouds when observed from a particular location"@en .
+
+brick:Cold_Box a owl:Class ;
+    rdfs:label "Cold Box" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Cold ;
+                        owl:onProperty brick:hasTag ] _:has_Box _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    skos:definition "in a gas separation unit, the insulated section that contains the low-temperature heat exchangers and distillation columns."@en ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Cold,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
+
+brick:Coldest_Zone_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Coldest Zone Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Coldest ;
+                        owl:onProperty brick:hasTag ] _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Zone_Air_Temperature_Sensor ;
+    skos:definition "The zone temperature that is coldest; drives the supply temperature of hot air. A computed value rather than a physical sensor. Also referred to as a 'Lowest Zone Air Temperature Sensor'"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Coldest,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Zone .
+
+brick:Collection_Basin_Water_Heater a owl:Class ;
+    rdfs:label "Collection Basin Water Heater" ;
+    rdfs:seeAlso <https://www.coolingtowerworld.com/c-30-basin-heater.aspx> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Collection _:has_Basin _:has_Water _:has_Heater _:has_Equipment ) ],
+        brick:Water_Heater ;
+    skos:definition "Basin heaters prevent cold water basin freeze-up, e.g. in cooling towers, closed circuit fluid coolers, or evaporative condensers"@en ;
+    brick:hasAssociatedTag tag:Basin,
+        tag:Collection,
+        tag:Equipment,
+        tag:Heater,
+        tag:Water .
+
+brick:Collection_Basin_Water_Level_Alarm a owl:Class ;
+    rdfs:label "Collection Basin Water Level Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Collection _:has_Basin _:has_Water _:has_Level _:has_Alarm _:has_Point ) ],
+        brick:Water_Level_Alarm ;
+    skos:definition "An alarm that indicates a high or low level of water in the collection basin, e.g. within a Cooling_Tower"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Basin,
+        tag:Collection,
+        tag:Level,
+        tag:Point,
+        tag:Water .
+
+brick:Collection_Basin_Water_Level_Sensor a owl:Class ;
+    rdfs:label "Collection Basin Water Level Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Collection _:has_Basin _:has_Water _:has_Level _:has_Sensor _:has_Point ) ],
+        brick:Water_Level_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Collection_Basin_Water ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Level ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the level of the water in the collection basin, e.g. within a Cooling_Tower"@en ;
+    brick:hasAssociatedTag tag:Basin,
+        tag:Collection,
+        tag:Level,
+        tag:Point,
+        tag:Sensor,
+        tag:Water .
+
+brick:Collection_Basin_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Collection Basin Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Collection _:has_Basin _:has_Water _:has_Temperature _:has_Sensor _:has_Point ) ],
+        brick:Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Collection_Basin_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of the water in the collection basin, e.g. within a Cooling_Tower"@en ;
+    brick:hasAssociatedTag tag:Basin,
+        tag:Collection,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Communication_Loss_Alarm a owl:Class ;
+    rdfs:label "Communication Loss Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Communication ;
+                        owl:onProperty brick:hasTag ] _:has_Loss _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates a loss of communication e.g. with a device or controller"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Communication,
+        tag:Loss,
+        tag:Point .
+
+brick:Complex_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Complex Power" ;
+    owl:sameAs qudtqk:ComplexPower ;
+    skos:broader brick:Electric_Power ;
+    skos:definition "Complex Power, under sinusoidal conditions, is the product of the phasor (U) representing the voltage between the terminals of a linear two-terminal element or two-terminal circuit and the complex conjugate of the phasor (I) representing the electric current in the element or circuit."@en .
+
+brick:Compressor a owl:Class ;
+    rdfs:label "Compressor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Compressor ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "(1) device for mechanically increasing the pressure of a gas. (2) often described as being either open, hermetic, or semihermetic to describe how the compressor and motor drive is situated in relation to the gas or vapor being compressed. Types include centrifugal, axial flow, reciprocating, rotary screw, rotary vane, scroll, or diaphragm. 1. device for mechanically increasing the pressure of a gas. 2. specific machine, with or without accessories, for compressing refrigerant vapor."@en ;
+    brick:hasAssociatedTag tag:Compressor,
+        tag:Equipment .
+
+brick:Concession a owl:Class ;
+    rdfs:label "Concession" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Concessions ;
+                        owl:onProperty brick:hasTag ] _:has_Food _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Food_Service_Room ;
+    skos:definition "A space to sell food and beverages. Usually embedded in a larger space and does not include a space where people consume their purchases"@en ;
+    brick:hasAssociatedTag tag:Concessions,
+        tag:Food,
+        tag:Location,
+        tag:Room,
+        tag:Service,
+        tag:Space .
+
+brick:Condensate_Leak_Alarm a owl:Class ;
+    rdfs:label "Condensate Leak Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Condensate ;
+                        owl:onProperty brick:hasTag ] _:has_Leak _:has_Alarm ) ],
+        brick:Leak_Alarm ;
+    skos:definition "An alarm that indicates a leak of condensate from a cooling system"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Condensate,
+        tag:Leak,
+        tag:Point .
+
+brick:Condenser a owl:Class ;
+    rdfs:label "Condenser" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Condenser ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "A heat exchanger in which the primary heat transfer vapor changes its state to a liquid phase."@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment .
+
+brick:Condenser_Heat_Exchanger a owl:Class ;
+    rdfs:label "Condenser Heat Exchanger" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Condenser _:has_Equipment _:has_Heat _:has_Exchanger ) ],
+        brick:Heat_Exchanger ;
+    skos:definition "A heat exchanger in which the primary heat transfer vapor changes its state to a liquid phase."@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment,
+        tag:Exchanger,
+        tag:Heat .
+
+brick:Condenser_Water_Bypass_Valve a owl:Class ;
+    rdfs:label "Condenser Water Bypass Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Condenser _:has_Water _:has_Bypass _:has_Valve _:has_Equipment ) ],
+        brick:Bypass_Valve ;
+    skos:definition "A valve installed in a bypass line of a condenser water loop"@en ;
+    brick:hasAssociatedTag tag:Bypass,
+        tag:Condenser,
+        tag:Equipment,
+        tag:Valve,
+        tag:Water .
+
+brick:Condenser_Water_Isolation_Valve a owl:Class ;
+    rdfs:label "Condenser Water Isolation Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Condenser _:has_Water _:has_Isolation _:has_Valve _:has_Equipment ) ],
+        brick:Isolation_Valve ;
+    skos:definition "An isolation valve installed in the condenser water loop"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment,
+        tag:Isolation,
+        tag:Valve,
+        tag:Water .
+
+brick:Condenser_Water_Pump a owl:Class ;
+    rdfs:label "Condenser Water Pump" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Condenser _:has_Water ) ],
+        brick:Water_Pump ;
+    skos:definition "A pump that is part of a condenser system; the pump circulates condenser water from the chiller back to the cooling tower"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment,
+        tag:Pump,
+        tag:Water .
+
+brick:Condenser_Water_System a owl:Class ;
+    rdfs:label "Condenser Water System" ;
+    rdfs:seeAlso <https://www.linquip.com/blog/condenser-water-system-an-overview/> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Condenser _:has_Water _:has_System ) ],
+        brick:Water_System ;
+    skos:definition "A heat rejection system consisting of (typically) cooling towers, condenser water pumps, chillers and the piping connecting the components"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:System,
+        tag:Water .
+
+brick:Condenser_Water_Valve a owl:Class ;
+    rdfs:label "Condenser Water Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Condenser _:has_Valve _:has_Water _:has_Equipment ) ],
+        brick:Water_Valve ;
+    skos:definition "A valve that modulates the flow of condenser water"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Equipment,
+        tag:Valve,
+        tag:Water .
+
+brick:Conference_Room a owl:Class ;
+    rdfs:label "Conference Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Conference ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A space dedicated in which to hold a meetings"@en ;
+    brick:hasAssociatedTag tag:Conference,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Constant_Air_Volume_Box a owl:Class ;
+    rdfs:label "Constant Air Volume Box" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Constant_air_volume> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Constant ;
+                        owl:onProperty brick:hasTag ] _:has_Volume _:has_Box ) ],
+        brick:Terminal_Unit ;
+    owl:equivalentClass brick:CAV ;
+    skos:definition "A terminal unit for which supply air flow rate is constant and the supply air temperature is varied to meet thermal load"@en ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Constant,
+        tag:Equipment,
+        tag:Volume .
+
+brick:Contact_Sensor a owl:Class ;
+    rdfs:label "Contact Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
+                        owl:hasValue tag:Contact ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Sensor ;
+    skos:definition "Senses or detects contact, such as for determining if a door is closed."@en ;
+    brick:hasAssociatedTag tag:Contact,
+        tag:Point,
+        tag:Sensor .
+
+brick:Control_Room a owl:Class ;
+    rdfs:label "Control Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Control _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A space from which operations are managed"@en ;
+    brick:hasAssociatedTag tag:Control,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Cooling_Command a owl:Class ;
+    rdfs:label "Cooling Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls the amount of cooling to be delivered (typically as a proportion of total cooling output)"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Cool,
+        tag:Point .
+
+brick:Cooling_Demand_Setpoint a owl:Class ;
+    rdfs:label "Cooling Demand Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Demand _:has_Setpoint ) ],
+        brick:Demand_Setpoint ;
+    skos:definition "Sets the rate required for cooling"@en ;
+    brick:hasAssociatedTag tag:Cool,
+        tag:Demand,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Cooling_Start_Stop_Status a owl:Class ;
+    rdfs:label "Cooling Start Stop Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Start _:has_Stop _:has_Status ) ],
+        brick:Start_Stop_Status ;
+    brick:hasAssociatedTag tag:Cool,
+        tag:Point,
+        tag:Start,
+        tag:Status,
+        tag:Stop .
+
+brick:Cooling_Supply_Air_Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Cooling Supply Air Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Cooling_Temperature_Setpoint,
+        brick:Supply_Air_Temperature_Deadband_Setpoint ;
+    owl:equivalentClass brick:Cooling_Discharge_Air_Temperature_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature of supply air for cooling"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Deadband,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Cooling_Supply_Air_Temperature_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Cooling Supply Air Temperature Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Air_Temperature_Integral_Time_Parameter ;
+    owl:equivalentClass brick:Cooling_Discharge_Air_Temperature_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Supply,
+        tag:Temperature,
+        tag:Time .
+
+brick:Cooling_Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Cooling Supply Air Temperature Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Supply_Air_Temperature_Proportional_Band_Parameter ;
+    owl:equivalentClass brick:Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:Cool,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Cooling_Tower a owl:Class ;
+    rdfs:label "Cooling Tower" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Cooling_tower> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Cooling _:has_Tower ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "A cooling tower is a heat rejection device that rejects waste heat to the atmosphere through the cooling of a water stream to a lower temperature. Cooling towers may either use the evaporation of water to remove process heat and cool the working fluid to near the wet-bulb air temperature or, in the case of closed circuit dry cooling towers, rely solely on air to cool the working fluid to near the dry-bulb air temperature."@en ;
+    brick:hasAssociatedTag tag:Cooling,
+        tag:Equipment,
+        tag:Tower .
+
+brick:Cooling_Tower_Fan a owl:Class ;
+    rdfs:label "Cooling Tower Fan" ;
+    rdfs:seeAlso <https://highperformancehvac.com/cooling-tower-fan/> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Cool _:has_Tower _:has_Equipment _:has_Fan ) ],
+        brick:Fan ;
+    skos:definition "A fan that pulls air through a cooling tower and across the louvers where the water falls to aid in heat exchange by the process of evaporation"@en ;
+    brick:hasAssociatedTag tag:Cool,
+        tag:Equipment,
+        tag:Fan,
+        tag:Tower .
+
+brick:Cooling_Valve a owl:Class ;
+    rdfs:label "Cooling Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Cool _:has_Equipment ) ],
+        brick:Valve ;
+    skos:definition "A valve that controls air temperature by modulating the amount of cold water flowing through a cooling coil"@en ;
+    brick:hasAssociatedTag tag:Cool,
+        tag:Equipment,
+        tag:Valve .
+
+brick:Copy_Room a owl:Class ;
+    rdfs:label "Copy Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Copy ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A room set aside for common office equipment, including printers and copiers"@en ;
+    brick:hasAssociatedTag tag:Copy,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Cubicle a owl:Class ;
+    rdfs:label "Cubicle" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Cubicle ;
+                        owl:onProperty brick:hasTag ] _:has_Office _:has_Room _:has_Space _:has_Location ) ],
+        brick:Office ;
+    skos:definition "A smaller space set aside for an individual, but not with a door and without full-height walls"@en ;
+    brick:hasAssociatedTag tag:Cubicle,
+        tag:Location,
+        tag:Office,
+        tag:Room,
+        tag:Space .
+
+brick:Current_Angle a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Current Angle",
+        "CurrentAngle" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Phasor_Angle ;
+    skos:definition "Angle of current phasor",
+        "Angle of current phasor"@en ;
+    skos:related brick:Electric_Current .
+
+brick:Current_Imbalance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Current Imbalance",
+        "CurrentImbalance" ;
+    qudt:applicableUnit unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Dimensionless ;
+    skos:definition "The percent deviation from average current",
+        "The percent deviation from average current"@en ;
+    skos:related brick:Electric_Current .
+
+brick:Current_Limit a owl:Class ;
+    rdfs:label "Current Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Current _:has_Limit _:has_Parameter ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Current_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Current,
+        tag:Limit,
+        tag:Parameter,
+        tag:Point .
+
+brick:Current_Total_Harmonic_Distortion a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Current Total Harmonic Distortion",
+        "CurrentTotalHarmonicDistortion" ;
+    qudt:applicableUnit unit:DeciB_M,
+        unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Dimensionless ;
+    skos:definition "Measurement of harmonic distortion present in a signal defined as the sum of the powers of all harmonic components to the power of the fundamental frequency. (https://en.wikipedia.org/wiki/Total_harmonic_distortion)",
+        "Measurement of harmonic distortion present in a signal defined as the sum of the powers of all harmonic components to the power of the fundamental frequency. (https://en.wikipedia.org/wiki/Total_harmonic_distortion)"@en ;
+    skos:related brick:Electric_Current .
+
+brick:Curtailment_Override_Command a owl:Class ;
+    rdfs:label "Curtailment Override Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Curtailment ;
+                        owl:onProperty brick:hasTag ] _:has_Override _:has_Command ) ],
+        brick:Override_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Curtailment,
+        tag:Override,
+        tag:Point .
+
+brick:DC_Bus_Voltage_Sensor a owl:Class ;
+    rdfs:label "DC Bus Voltage Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Dc ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Bus ;
+                        owl:onProperty brick:hasTag ] _:has_Voltage _:has_Sensor ) ],
+        brick:Voltage_Sensor ;
+    skos:definition "Measures the voltage across a DC bus"@en ;
+    brick:hasAssociatedTag tag:Bus,
+        tag:Dc,
+        tag:Point,
+        tag:Sensor,
+        tag:Voltage .
+
+brick:Damper_Position_Command a owl:Class ;
+    rdfs:label "Damper Position Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Position _:has_Command ) ],
+        brick:Damper_Command,
+        brick:Position_Command ;
+    skos:definition "Controls the position (the degree of openness) of a damper"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Damper,
+        tag:Point,
+        tag:Position .
+
+brick:Damper_Position_Sensor a owl:Class ;
+    rdfs:label "Damper Position Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Position _:has_Sensor ) ],
+        brick:Position_Sensor ;
+    skos:definition "Measures the current position of a damper in terms of the percent of fully open"@en ;
+    brick:hasAssociatedTag tag:Damper,
+        tag:Point,
+        tag:Position,
+        tag:Sensor .
+
+brick:Damper_Position_Setpoint a owl:Class ;
+    rdfs:label "Damper Position Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Position _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets the position of damper"@en ;
+    brick:hasAssociatedTag tag:Damper,
+        tag:Point,
+        tag:Position,
+        tag:Setpoint .
+
+brick:Deceleration_Time a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Deceleration Time" ;
+    skos:broader brick:Time .
+
+brick:Deceleration_Time_Setpoint a owl:Class ;
+    rdfs:label "Deceleration Time Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Time _:has_Setpoint [ a owl:Restriction ;
+                        owl:hasValue tag:Deceleration ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Time_Setpoint ;
+    brick:hasAssociatedTag tag:Deceleration,
+        tag:Point,
+        tag:Setpoint,
+        tag:Time .
+
+brick:Dehumidification_Start_Stop_Status a owl:Class ;
+    rdfs:label "Dehumidification Start Stop Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Dehumidification ;
+                        owl:onProperty brick:hasTag ] _:has_Start _:has_Stop _:has_Status ) ],
+        brick:Start_Stop_Status ;
+    brick:hasAssociatedTag tag:Dehumidification,
+        tag:Point,
+        tag:Start,
+        tag:Status,
+        tag:Stop .
+
+brick:Deionised_Water_Conductivity_Sensor a owl:Class ;
+    rdfs:label "Deionised Water Conductivity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Conductivity _:has_Water _:has_Deionised ) ],
+        brick:Conductivity_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Conductivity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Deionized_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the electrical conductance of deionised water"@en ;
+    brick:hasAssociatedTag tag:Conductivity,
+        tag:Deionised,
+        tag:Point,
+        tag:Sensor,
+        tag:Water .
+
+brick:Deionised_Water_Level_Sensor a owl:Class ;
+    rdfs:label "Deionised Water Level Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Water _:has_Level _:has_Deionised ) ],
+        brick:Water_Level_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Deionized_Water ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Level ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the height/level of deionised water in some container"@en ;
+    brick:hasAssociatedTag tag:Deionised,
+        tag:Level,
+        tag:Point,
+        tag:Sensor,
+        tag:Water .
+
+brick:Deionized_Water_Alarm a owl:Class ;
+    rdfs:label "Deionized Water Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Deionized _:has_Water _:has_Alarm ) ],
+        brick:Water_Alarm ;
+    skos:definition "An alarm that indicates deionized water leaks."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Deionized,
+        tag:Point,
+        tag:Water .
+
+brick:Derivative_Gain_Parameter a owl:Class ;
+    rdfs:label "Derivative Gain Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Derivative ) ],
+        brick:Gain_Parameter ;
+    brick:hasAssociatedTag tag:Derivative,
+        tag:Gain,
+        tag:PID,
+        tag:Parameter,
+        tag:Point .
+
+brick:Derivative_Time_Parameter a owl:Class ;
+    rdfs:label "Derivative Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Time _:has_Derivative ) ],
+        brick:Time_Parameter ;
+    brick:hasAssociatedTag tag:Derivative,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Time .
+
+brick:Detention_Room a owl:Class ;
+    rdfs:label "Detention Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Detention ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Security_Service_Room ;
+    skos:definition "A space for the temporary involuntary confinement of people"@en ;
+    brick:hasAssociatedTag tag:Detention,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Dew_Point_Setpoint a owl:Class ;
+    rdfs:label "Dew Point Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Dewpoint _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets dew point"@en ;
+    brick:hasAssociatedTag tag:Dewpoint,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Differential_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Differential Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of diffrential air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Differential_Pressure_Bypass_Valve a owl:Class ;
+    rdfs:label "Differential Pressure Bypass Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Differential _:has_Pressure _:has_Bypass _:has_Valve _:has_Equipment ) ],
+        brick:Bypass_Valve ;
+    skos:definition "A 2-way, self contained proportional valve with an integral differential pressure adjustment setting."@en ;
+    brick:hasAssociatedTag tag:Bypass,
+        tag:Differential,
+        tag:Equipment,
+        tag:Pressure,
+        tag:Valve .
+
+brick:Differential_Speed_Sensor a owl:Class ;
+    rdfs:label "Differential Speed Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Speed _:has_Differential ) ],
+        brick:Speed_Sensor ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Point,
+        tag:Sensor,
+        tag:Speed .
+
+brick:Differential_Speed_Setpoint a owl:Class ;
+    rdfs:label "Differential Speed Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Speed _:has_Setpoint ) ],
+        brick:Speed_Setpoint ;
+    skos:definition "Sets differential speed"@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Point,
+        tag:Setpoint,
+        tag:Speed .
+
+brick:Differential_Supply_Return_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Differential Supply Return Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Supply _:has_Return _:has_Temperature _:has_Sensor ) ],
+        brick:Return_Water_Temperature_Sensor ;
+    skos:definition "Measures the difference in temperature between return and supply water"@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Dimmer a owl:Class ;
+    rdfs:label "Dimmer" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface _:has_Switch [ a owl:Restriction ;
+                        owl:hasValue tag:Dimmer ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Switch ;
+    skos:definition "A switch providing continuous control over all or part of a lighting installation; typically potentiometer-based"@en ;
+    brick:hasAssociatedTag tag:Dimmer,
+        tag:Equipment,
+        tag:Interface,
+        tag:Switch .
+
+brick:Direction_Command a owl:Class ;
+    rdfs:label "Direction Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Direction _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Commands that affect the direction of some phenomenon"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Direction,
+        tag:Point .
+
+brick:Disable_Differential_Enthalpy_Command a owl:Class ;
+    rdfs:label "Disable Differential Enthalpy Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Differential _:has_Enthalpy ) ],
+        brick:Disable_Command ;
+    skos:definition "Disables the use of differential enthalpy control"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Differential,
+        tag:Disable,
+        tag:Enthalpy,
+        tag:Point .
+
+brick:Disable_Differential_Temperature_Command a owl:Class ;
+    rdfs:label "Disable Differential Temperature Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Differential _:has_Temperature ) ],
+        brick:Disable_Command ;
+    skos:definition "Disables the use of differential temperature control"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Differential,
+        tag:Disable,
+        tag:Point,
+        tag:Temperature .
+
+brick:Disable_Fixed_Enthalpy_Command a owl:Class ;
+    rdfs:label "Disable Fixed Enthalpy Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
+        brick:Disable_Command ;
+    skos:definition "Disables the use of fixed enthalpy control"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Disable,
+        tag:Enthalpy,
+        tag:Fixed,
+        tag:Point .
+
+brick:Disable_Fixed_Temperature_Command a owl:Class ;
+    rdfs:label "Disable Fixed Temperature Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Fixed _:has_Temperature ) ],
+        brick:Disable_Command ;
+    skos:definition "Disables the use of fixed temperature temperature"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Disable,
+        tag:Fixed,
+        tag:Point,
+        tag:Temperature .
+
+brick:Disable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Disable Hot Water System Outside Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Outside_Air_Temperature_Setpoint ;
+    skos:definition "Disables hot water system when outside air temperature reaches the indicated value"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Disable,
+        tag:Hot,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint,
+        tag:System,
+        tag:Temperature,
+        tag:Water .
+
+brick:Disable_Status a owl:Class ;
+    rdfs:label "Disable Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if functionality has been disabled"@en ;
+    brick:hasAssociatedTag tag:Disable,
+        tag:Point,
+        tag:Status .
+
+brick:Discharge_Air_Dewpoint_Sensor a owl:Class ;
+    rdfs:label "Discharge Air Dewpoint Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint _:has_Air _:has_Discharge ) ],
+        brick:Dewpoint_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Dewpoint ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Discharge_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures dewpoint of discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Dewpoint,
+        tag:Discharge,
+        tag:Point,
+        tag:Sensor .
+
+brick:Discharge_Air_Flow_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Flow High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_High ) ],
+        brick:Discharge_Air_Flow_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:High,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint .
+
+brick:Discharge_Air_Flow_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Flow Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint _:has_Low ) ],
+        brick:Discharge_Air_Flow_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint .
+
+brick:Discharge_Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air _:has_Discharge ) ],
+        brick:Air_Humidity_Setpoint ;
+    skos:definition "Humidity setpoint for discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Humidity,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Discharge_Air_Smoke_Detection_Alarm a owl:Class ;
+    rdfs:label "Discharge Air Smoke Detection Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Smoke _:has_Detection _:has_Alarm ) ],
+        brick:Air_Alarm,
+        brick:Smoke_Detection_Alarm ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Detection,
+        tag:Discharge,
+        tag:Point,
+        tag:Smoke .
+
+brick:Discharge_Air_Static_Pressure_Step_Parameter a owl:Class ;
+    rdfs:label "Discharge Air Static Pressure Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
+        brick:Air_Static_Pressure_Step_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Static,
+        tag:Step .
+
+brick:Discharge_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Discharge Water Differential Pressure Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Differential_Pressure_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Discharge,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Time,
+        tag:Water .
+
+brick:Discharge_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Discharge Water Differential Pressure Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Differential_Pressure_Proportional_Band ;
+    brick:hasAssociatedTag tag:Band,
+        tag:Differential,
+        tag:Discharge,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Proportional,
+        tag:Water .
+
+brick:Discharge_Water_Temperature_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Discharge Water Temperature Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Proportional_Band_Parameter,
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Band,
+        tag:Discharge,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Temperature,
+        tag:Water .
+
+brick:Discharge_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Discharge Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Discharge ) ],
+        brick:Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Discharge_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of discharge water"@en ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Discharge_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Discharge Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Temperature _:has_Setpoint ) ],
+        brick:Water_Temperature_Setpoint ;
+    skos:definition "Sets temperature of discharge water"@en ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+brick:Disconnect_Switch a owl:Class ;
+    rdfs:label "Disconnect Switch" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Disconnect ;
+                        owl:onProperty brick:hasTag ] _:has_Switch _:has_Equipment ) ],
+        brick:Electrical_Equipment ;
+    skos:definition "Building power is most commonly provided by utility company through a master disconnect switch (sometimes called a service disconnect) in the main electrical room of a building. The Utility Company provided master disconnect switch often owns or restricts access to this switch. There can also be other cases where a disconnect is placed into an electrical system to allow service cut-off to a portion of the building."@en ;
+    brick:hasAssociatedTag tag:Disconnect,
+        tag:Equipment,
+        tag:Switch .
+
+brick:Domestic_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
+    rdfs:label "Domestic Hot Water Supply Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Domestic _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+        brick:Hot_Water_Supply_Temperature_Sensor ;
+    skos:definition "Measures the temperature of domestic water supplied by a hot water system"@en ;
+    brick:hasAssociatedTag tag:Domestic,
+        tag:Hot,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Domestic_Hot_Water_Supply_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Domestic Hot Water Supply Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Domestic _:has_Hot _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
+        brick:Domestic_Hot_Water_Temperature_Setpoint,
+        brick:Supply_Water_Temperature_Setpoint ;
+    skos:definition "Sets temperature of supplying part of domestic hot water"@en ;
+    brick:hasAssociatedTag tag:Domestic,
+        tag:Hot,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Domestic_Hot_Water_System a owl:Class ;
+    rdfs:label "Domestic Hot Water System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Domestic _:has_Water _:has_Hot _:has_System ) ],
+        brick:System ;
+    skos:definition "The equipment, devices and conduits that handle the production and distribution of domestic hot water in a building"@en ;
+    brick:hasAssociatedTag tag:Domestic,
+        tag:Hot,
+        tag:System,
+        tag:Water .
+
+brick:Domestic_Hot_Water_System_Enable_Command a owl:Class ;
+    rdfs:label "Domestic Hot Water System Enable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Domestic _:has_Hot _:has_Water _:has_System ) ],
+        brick:Hot_Water_System_Enable_Command ;
+    skos:definition "Enables operation of the domestic hot water system"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Domestic,
+        tag:Enable,
+        tag:Hot,
+        tag:Point,
+        tag:System,
+        tag:Water .
+
+brick:Domestic_Hot_Water_Valve a owl:Class ;
+    rdfs:label "Domestic Hot Water Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Domestic _:has_Water _:has_Hot _:has_Valve _:has_Heat _:has_Equipment ) ],
+        brick:Hot_Water_Valve ;
+    skos:definition "A valve regulating the flow of domestic hot water"@en ;
+    brick:hasAssociatedTag tag:Domestic,
+        tag:Equipment,
+        tag:Heat,
+        tag:Hot,
+        tag:Valve,
+        tag:Water .
+
+brick:Drench_Hose a owl:Class ;
+    rdfs:label "Drench Hose" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Safety _:has_Wash _:has_Station _:has_Emergency [ a owl:Restriction ;
+                        owl:hasValue tag:Drench ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Hose ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Emergency_Wash_Station ;
+    brick:hasAssociatedTag tag:Drench,
+        tag:Emergency,
+        tag:Equipment,
+        tag:Hose,
+        tag:Safety,
+        tag:Station,
+        tag:Wash .
+
+brick:Drive_Ready_Status a owl:Class ;
+    rdfs:label "Drive Ready Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Drive [ a owl:Restriction ;
+                        owl:hasValue tag:Ready ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if a hard drive or other storage device is ready to be used, e.g. in the context of RAID"@en ;
+    brick:hasAssociatedTag tag:Drive,
+        tag:Point,
+        tag:Ready,
+        tag:Status .
+
+brick:Dry_Bulb_Temperature a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Dry Bulb Temperature",
+        "Dry_Bulb_Temperature" ;
+    qudt:applicableUnit unit:DEG_C,
+        unit:DEG_F,
+        unit:K ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:ThermodynamicTemperature,
+        brick:Temperature ;
+    skos:definition "The temperature of air measured by a thermometer freely exposed to the air, but shielded from radiation and moisture. (https://en.wikipedia.org/wiki/Dry-bulb_temperature)",
+        "The temperature of air measured by a thermometer freely exposed to the air, but shielded from radiation and moisture. (https://en.wikipedia.org/wiki/Dry-bulb_temperature)"@en .
+
+brick:EconCycle_Start_Stop_Status a owl:Class ;
+    rdfs:label "EconCycle Start Stop Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Econcycle ;
+                        owl:onProperty brick:hasTag ] _:has_Start _:has_Stop _:has_Status ) ],
+        brick:Start_Stop_Status ;
+    brick:hasAssociatedTag tag:Econcycle,
+        tag:Point,
+        tag:Start,
+        tag:Status,
+        tag:Stop .
+
+brick:Economizer a owl:Class ;
+    rdfs:label "Economizer" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Economizer ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "Device that, on proper variable sensing, initiates control signals or actions to conserve energy. A control system that reduces the mechanical heating and cooling requirement."@en ;
+    brick:hasAssociatedTag tag:Economizer,
+        tag:Equipment .
+
+brick:Economizer_Damper a owl:Class ;
+    rdfs:label "Economizer Damper" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper _:has_Economizer ) ],
+        brick:Damper ;
+    skos:definition "A damper that is part of an economizer that is used to module the flow of air"@en ;
+    brick:hasAssociatedTag tag:Damper,
+        tag:Economizer,
+        tag:Equipment .
+
+brick:Effective_Air_Temperature_Cooling_Setpoint a owl:Class ;
+    rdfs:label "Effective Air Temperature Cooling Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Effective _:has_Air _:has_Cool _:has_Temperature _:has_Setpoint ) ],
+        brick:Cooling_Temperature_Setpoint,
+        brick:Effective_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Effective,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Effective_Air_Temperature_Heating_Setpoint a owl:Class ;
+    rdfs:label "Effective Air Temperature Heating Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Effective _:has_Air _:has_Heat _:has_Temperature _:has_Setpoint ) ],
+        brick:Effective_Air_Temperature_Setpoint,
+        brick:Heating_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Effective,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Effective_Discharge_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Effective Discharge Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Effective ) ],
+        brick:Discharge_Air_Temperature_Setpoint,
+        brick:Effective_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Effective,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Effective_Return_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Effective Return Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Effective ) ],
+        brick:Effective_Air_Temperature_Setpoint,
+        brick:Return_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Effective,
+        tag:Heat,
+        tag:Point,
+        tag:Return,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Effective_Room_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Effective Room Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Room _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Effective ) ],
+        brick:Effective_Air_Temperature_Setpoint,
+        brick:Room_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Effective,
+        tag:Heat,
+        tag:Point,
+        tag:Room,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Effective_Supply_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Effective Supply Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Effective ) ],
+        brick:Effective_Air_Temperature_Setpoint,
+        brick:Supply_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Effective,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Effective_Zone_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Effective Zone Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Effective ) ],
+        brick:Effective_Air_Temperature_Setpoint,
+        brick:Zone_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Effective,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Zone .
+
+brick:Electric_Baseboard_Radiator a owl:Class ;
+    rdfs:label "Electric Baseboard Radiator" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Radiator _:has_Baseboard _:has_Electric ) ],
+        brick:Baseboard_Radiator,
+        brick:Electric_Radiator ;
+    skos:definition "Electric heating device located at or near the floor"@en ;
+    brick:hasAssociatedTag tag:Baseboard,
+        tag:Electric,
+        tag:Equipment,
+        tag:Radiator .
+
+brick:Electrical_System a owl:Class ;
+    rdfs:label "Electrical System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_System ) ],
+        brick:System ;
+    skos:definition "Devices that serve or are part of the electrical subsystem in the building"@en ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:System .
+
+brick:Elevator a owl:Class ;
+    rdfs:label "Elevator" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Elevator> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Elevator _:has_Equipment ) ],
+        brick:Equipment ;
+    skos:definition "A device that provides vertical transportation between floors, levels or decks of a building, vessel or other structure"@en ;
+    brick:hasAssociatedTag tag:Elevator,
+        tag:Equipment .
+
+brick:Emergency_Air_Flow_System a owl:Class ;
+    rdfs:label "Emergency Air Flow System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Air _:has_Flow _:has_System ) ],
+        brick:Safety_System ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Emergency,
+        tag:Flow,
+        tag:System .
+
+brick:Emergency_Air_Flow_System_Status a owl:Class ;
+    rdfs:label "Emergency Air Flow System Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Air _:has_Flow _:has_System _:has_Status ) ],
+        brick:System_Status ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Emergency,
+        tag:Flow,
+        tag:Point,
+        tag:Status,
+        tag:System .
+
+brick:Emergency_Generator_Alarm a owl:Class ;
+    rdfs:label "Emergency Generator Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Generator _:has_Emergency _:has_Alarm ) ],
+        brick:Emergency_Alarm ;
+    skos:definition "An alarm that indicates off-normal conditions associated with an emergency generator"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Emergency,
+        tag:Generator,
+        tag:Point .
+
+brick:Emergency_Generator_Status a owl:Class ;
+    rdfs:label "Emergency Generator Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Generator _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if an emergency generator is active"@en ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Generator,
+        tag:Point,
+        tag:Status .
+
+brick:Emergency_Phone a owl:Class ;
+    rdfs:label "Emergency Phone" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Security _:has_Intercom _:has_Emergency [ a owl:Restriction ;
+                        owl:hasValue tag:Phone ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Intercom_Equipment ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Equipment,
+        tag:Intercom,
+        tag:Phone,
+        tag:Security .
+
+brick:Emergency_Power_Off_System a owl:Class ;
+    rdfs:label "Emergency Power Off System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Emergency _:has_Power _:has_Off _:has_System ) ],
+        brick:Safety_System ;
+    skos:definition "A system that can power down a single piece of equipment or a single system from a single point"@en ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Off,
+        tag:Power,
+        tag:System .
+
+brick:Emergency_Power_Off_System_Activated_By_High_Temperature_Status a owl:Class ;
+    rdfs:label "Emergency Power Off System Activated By High Temperature Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_System _:has_High _:has_Temperature _:has_Status ) ],
+        brick:Emergency_Power_Off_System_Status ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:High,
+        tag:Off,
+        tag:Point,
+        tag:Power,
+        tag:Status,
+        tag:System,
+        tag:Temperature .
+
+brick:Emergency_Power_Off_System_Activated_By_Leak_Detection_System_Status a owl:Class ;
+    rdfs:label "Emergency Power Off System Activated By Leak Detection System Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_System _:has_Leak _:has_Detection _:has_Status ) ],
+        brick:Emergency_Power_Off_System_Status ;
+    brick:hasAssociatedTag tag:Detection,
+        tag:Emergency,
+        tag:Leak,
+        tag:Off,
+        tag:Point,
+        tag:Power,
+        tag:Status,
+        tag:System .
+
+brick:Emergency_Push_Button_Status a owl:Class ;
+    rdfs:label "Emergency Push Button Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency [ a owl:Restriction ;
+                        owl:hasValue tag:Push ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Button ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if an emergency button has been pushed"@en ;
+    brick:hasAssociatedTag tag:Button,
+        tag:Emergency,
+        tag:Point,
+        tag:Push,
+        tag:Status .
+
+brick:Employee_Entrance_Lobby a owl:Class ;
+    rdfs:label "Employee Entrance Lobby" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Employee ;
+                        owl:onProperty brick:hasTag ] _:has_Entrance _:has_Lobby _:has_Common _:has_Space _:has_Location ) ],
+        brick:Lobby ;
+    skos:definition "An open space near an entrance that is typicaly only used for employees"@en ;
+    brick:hasAssociatedTag tag:Common,
+        tag:Employee,
+        tag:Entrance,
+        tag:Lobby,
+        tag:Location,
+        tag:Space .
+
+brick:Enable_Differential_Enthalpy_Command a owl:Class ;
+    rdfs:label "Enable Differential Enthalpy Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Differential _:has_Enthalpy ) ],
+        brick:Enable_Command ;
+    skos:definition "Enables the use of differential enthalpy control"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Differential,
+        tag:Enable,
+        tag:Enthalpy,
+        tag:Point .
+
+brick:Enable_Differential_Temperature_Command a owl:Class ;
+    rdfs:label "Enable Differential Temperature Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Differential _:has_Temperature ) ],
+        brick:Enable_Command ;
+    skos:definition "Enables the use of differential temperature control"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Differential,
+        tag:Enable,
+        tag:Point,
+        tag:Temperature .
+
+brick:Enable_Fixed_Enthalpy_Command a owl:Class ;
+    rdfs:label "Enable Fixed Enthalpy Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Fixed _:has_Enthalpy ) ],
+        brick:Enable_Command ;
+    skos:definition "Enables the use of fixed enthalpy control"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Enable,
+        tag:Enthalpy,
+        tag:Fixed,
+        tag:Point .
+
+brick:Enable_Fixed_Temperature_Command a owl:Class ;
+    rdfs:label "Enable Fixed Temperature Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Fixed _:has_Temperature ) ],
+        brick:Enable_Command ;
+    skos:definition "Enables the use of fixed temperature control"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Enable,
+        tag:Fixed,
+        tag:Point,
+        tag:Temperature .
+
+brick:Enable_Hot_Water_System_Outside_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Enable Hot Water System Outside Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Hot _:has_Water _:has_System _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Outside_Air_Temperature_Setpoint ;
+    skos:definition "Enables hot water system when outside air temperature reaches the indicated value"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Enable,
+        tag:Hot,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint,
+        tag:System,
+        tag:Temperature,
+        tag:Water .
+
+brick:Energy_Usage_Sensor a owl:Class ;
+    rdfs:label "Energy Usage Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Energy _:has_Usage ) ],
+        brick:Energy_Sensor,
+        brick:Usage_Sensor ;
+    skos:definition "Measures the total amount of energy used over some period of time"@en ;
+    brick:hasAssociatedTag tag:Energy,
+        tag:Point,
+        tag:Sensor,
+        tag:Usage .
+
+brick:Energy_Zone a owl:Class ;
+    rdfs:label "Energy Zone" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Energy _:has_Zone _:has_Location ) ],
+        brick:Zone ;
+    skos:definition "A space or group of spaces that are managed or monitored as one unit for energy purposes"@en ;
+    brick:hasAssociatedTag tag:Energy,
+        tag:Location,
+        tag:Zone .
+
+brick:Entering_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Entering Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Entering ) ],
+        brick:Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Entering_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of water entering a condenser"@en ;
+    brick:hasAssociatedTag tag:Entering,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Entering_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Entering Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Entering _:has_Water _:has_Temperature _:has_Setpoint ) ],
+        brick:Water_Temperature_Setpoint ;
+    skos:definition "Sets temperature of entering water"@en ;
+    brick:hasAssociatedTag tag:Entering,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+brick:Enthalpy_Setpoint a owl:Class ;
+    rdfs:label "Enthalpy Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Setpoint _:has_Enthalpy ) ],
+        brick:Setpoint ;
+    skos:definition "Sets enthalpy"@en ;
+    brick:hasAssociatedTag tag:Enthalpy,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Entrance a owl:Class ;
+    rdfs:label "Entrance" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Entrance _:has_Space _:has_Location ) ],
+        brick:Space ;
+    skos:definition "The location and space of a building where people enter and exit the building"@en ;
+    brick:hasAssociatedTag tag:Entrance,
+        tag:Location,
+        tag:Space .
+
+brick:Environment_Box a owl:Class ;
+    rdfs:label "Environment Box" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Environment ;
+                        owl:onProperty brick:hasTag ] _:has_Box _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    skos:definition "(also known as climatic chamber), enclosed space designed to create a particular environment."@en ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Environment,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
+
+brick:Equipment_Room a owl:Class ;
+    rdfs:label "Equipment Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Telecom _:has_Room _:has_Space _:has_Location ) ],
+        brick:Telecom_Room ;
+    skos:definition "A telecommunications room where equipment that serves the building is stored"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:Telecom .
+
+brick:Evaporative_Heat_Exchanger a owl:Class ;
+    rdfs:label "Evaporative Heat Exchanger" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Evaporative ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment _:has_Heat _:has_Exchanger ) ],
+        brick:Heat_Exchanger ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Evaporative,
+        tag:Exchanger,
+        tag:Heat .
+
+brick:Even_Month_Status a owl:Class ;
+    rdfs:label "Even Month Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Even ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Month ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+        brick:Status ;
+    brick:hasAssociatedTag tag:Even,
+        tag:Month,
+        tag:Point,
+        tag:Status .
+
+brick:Exercise_Room a owl:Class ;
+    rdfs:label "Exercise Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Exercise ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "An indoor room used for exercise and physical activities"@en ;
+    brick:hasAssociatedTag tag:Exercise,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Exhaust_Air_Dewpoint_Sensor a owl:Class ;
+    rdfs:label "Exhaust Air Dewpoint Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint _:has_Air _:has_Exhaust ) ],
+        brick:Dewpoint_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Dewpoint ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Exhaust_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures dewpoint of exhaust air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Dewpoint,
+        tag:Exhaust,
+        tag:Point,
+        tag:Sensor .
+
+brick:Exhaust_Air_Humidity_Sensor a owl:Class ;
+    rdfs:label "Exhaust Air Humidity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Relative _:has_Air _:has_Exhaust ) ],
+        brick:Relative_Humidity_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Relative_Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Exhaust_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the relative humidity of exhaust air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Humidity,
+        tag:Point,
+        tag:Relative,
+        tag:Sensor .
+
+brick:Exhaust_Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Exhaust Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air _:has_Exhaust ) ],
+        brick:Air_Humidity_Setpoint ;
+    skos:definition "Humidity setpoint for exhaust air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Humidity,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Exhaust_Air_Stack_Flow_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Exhaust Air Stack Flow Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Deadband _:has_Setpoint ) ],
+        brick:Air_Flow_Deadband_Setpoint,
+        brick:Exhaust_Air_Stack_Flow_Setpoint ;
+    skos:definition "Sets the size of a deadband of exhaust air stack flow"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Deadband,
+        tag:Exhaust,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint,
+        tag:Stack .
+
+brick:Exhaust_Air_Stack_Flow_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Exhaust Air Stack Flow Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Exhaust_Air_Flow_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Flow,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Stack,
+        tag:Time .
+
+brick:Exhaust_Air_Stack_Flow_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Exhaust Air Stack Flow Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Exhaust_Air_Flow_Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:Exhaust,
+        tag:Flow,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Stack .
+
+brick:Exhaust_Air_Stack_Flow_Sensor a owl:Class ;
+    rdfs:label "Exhaust Air Stack Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Sensor ) ],
+        brick:Exhaust_Air_Flow_Sensor ;
+    skos:definition "Measures the rate of flow of air in the exhaust air stack"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor,
+        tag:Stack .
+
+brick:Exhaust_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Exhaust Air Static Pressure Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Static_Pressure_Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:Exhaust,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Proportional,
+        tag:Static .
+
+brick:Exhaust_Air_Static_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Exhaust Air Static Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+        brick:Static_Pressure_Setpoint ;
+    skos:definition "Sets static pressure of exhaust air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Exhaust_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Exhaust Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Exhaust ) ],
+        brick:Air_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Exhaust_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of exhaust air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Exhaust_Air_Velocity_Pressure_Sensor a owl:Class ;
+    rdfs:label "Exhaust Air Velocity Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity _:has_Exhaust _:has_Air ) ],
+        brick:Velocity_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Velocity_Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Exhaust_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Velocity .
+
+brick:Exhaust_Damper a owl:Class ;
+    rdfs:label "Exhaust Damper" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper _:has_Exhaust ) ],
+        brick:Damper ;
+    skos:definition "A damper that modulates the flow of exhaust air"@en ;
+    brick:hasAssociatedTag tag:Damper,
+        tag:Equipment,
+        tag:Exhaust .
+
+brick:Exhaust_Fan a owl:Class ;
+    rdfs:label "Exhaust Fan" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_Exhaust ) ],
+        brick:Fan ;
+    skos:definition "Fan moving exhaust air -- air that must be removed from a space due to contaminants"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Exhaust,
+        tag:Fan .
+
+brick:Exhaust_Fan_Disable_Command a owl:Class ;
+    rdfs:label "Exhaust Fan Disable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command _:has_Fan _:has_Exhaust ) ],
+        brick:Disable_Command ;
+    skos:definition "Disables operation of the exhaust fan"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Disable,
+        tag:Exhaust,
+        tag:Fan,
+        tag:Point .
+
+brick:Exhaust_Fan_Enable_Command a owl:Class ;
+    rdfs:label "Exhaust Fan Enable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Fan _:has_Exhaust ) ],
+        brick:Enable_Command ;
+    skos:definition "Enables operation of the exhaust fan"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Enable,
+        tag:Exhaust,
+        tag:Fan,
+        tag:Point .
+
+brick:Eye_Wash_Station a owl:Class ;
+    rdfs:label "Eye Wash Station" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Safety _:has_Wash _:has_Station _:has_Emergency [ a owl:Restriction ;
+                        owl:hasValue tag:Eye ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Emergency_Wash_Station ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Equipment,
+        tag:Eye,
+        tag:Safety,
+        tag:Station,
+        tag:Wash .
+
+brick:Fan_Coil_Unit a owl:Class ;
+    rdfs:label "Fan Coil Unit" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Fan_coil_unit> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_Coil _:has_Unit ) ],
+        brick:Terminal_Unit ;
+    owl:equivalentClass brick:FCU ;
+    skos:definition "Terminal device consisting of a heating and/or cooling heat exchanger or 'coil' and fan that is used to control the temperature in the space where it is installed"@en ;
+    brick:hasAssociatedTag tag:Coil,
+        tag:Equipment,
+        tag:Fan,
+        tag:Unit .
+
+brick:Fan_On_Off_Status a owl:Class ;
+    rdfs:label "Fan On Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_On _:has_Off _:has_Status ) ],
+        brick:Fan_Status,
+        brick:On_Off_Status ;
+    brick:hasAssociatedTag tag:Fan,
+        tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Status .
+
+brick:Fan_VFD a owl:Class ;
+    rdfs:label "Fan VFD" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_VFD ) ],
+        brick:VFD ;
+    skos:definition "Variable-frequency drive for fans"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fan,
+        tag:VFD .
+
+brick:Fault_Reset_Command a owl:Class ;
+    rdfs:label "Fault Reset Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fault _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    skos:definition "Clears a fault status"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Fault,
+        tag:Point,
+        tag:Reset .
+
+brick:Field_Of_Play a owl:Class ;
+    rdfs:label "Field Of Play" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Location _:has_Outdoor _:has_Area [ a owl:Restriction ;
+                        owl:hasValue tag:Field ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Play ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Outdoor_Area ;
+    skos:definition "The area of a stadium where athletic events occur, e.g. the soccer pitch"@en ;
+    brick:hasAssociatedTag tag:Area,
+        tag:Field,
+        tag:Location,
+        tag:Outdoor,
+        tag:Play .
+
+brick:Filter_Differential_Pressure_Sensor a owl:Class ;
+    rdfs:label "Filter Differential Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential _:has_Filter ) ],
+        brick:Differential_Pressure_Sensor ;
+    skos:definition "Measures the difference in pressure on either side of a filter"@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Filter,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor .
+
+brick:Filter_Reset_Command a owl:Class ;
+    rdfs:label "Filter Reset Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Filter _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Filter,
+        tag:Point,
+        tag:Reset .
+
+brick:Final_Filter a owl:Class ;
+    rdfs:label "Final Filter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Final ;
+                        owl:onProperty brick:hasTag ] _:has_Filter ) ],
+        brick:Filter ;
+    skos:definition "The last, high-efficiency filter installed in a sequence to remove the finest particulates from the substance being filtered"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Filter,
+        tag:Final .
+
+brick:Fire_Control_Panel a owl:Class ;
+    rdfs:label "Fire Control Panel" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fire _:has_Safety [ a owl:Restriction ;
+                        owl:hasValue tag:Panel ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Fire_Safety_Equipment ;
+    skos:definition "A panel-mounted device that provides status and control of a fire safety system"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fire,
+        tag:Panel,
+        tag:Safety .
+
+brick:Fire_Safety_System a owl:Class ;
+    rdfs:label "Fire Safety System" ;
+    rdfs:seeAlso <https://assetinsights.net/Glossary/G_Fire_Safety_System.html> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fire _:has_Safety _:has_System ) ],
+        brick:Safety_System ;
+    skos:definition "A system containing devices and equipment that monitor, detect and suppress fire hazards"@en ;
+    brick:hasAssociatedTag tag:Fire,
+        tag:Safety,
+        tag:System .
+
+brick:Fire_Sensor a owl:Class ;
+    rdfs:label "Fire Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Fire ) ],
+        brick:Sensor ;
+    skos:definition "Measures the presence of fire"@en ;
+    brick:hasAssociatedTag tag:Fire,
+        tag:Point,
+        tag:Sensor .
+
+brick:Fire_Zone a owl:Class ;
+    rdfs:label "Fire Zone" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fire _:has_Zone _:has_Location ) ],
+        brick:Zone ;
+    skos:definition "combustion chamber in a furnace or boiler."@en ;
+    brick:hasAssociatedTag tag:Fire,
+        tag:Location,
+        tag:Zone .
+
+brick:First_Aid_Kit a owl:Class ;
+    rdfs:label "First Aid Kit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Safety _:has_Aid [ a owl:Restriction ;
+                        owl:hasValue tag:FirstAid ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Safety_Equipment ;
+    brick:hasAssociatedTag tag:Aid,
+        tag:Equipment,
+        tag:FirstAid,
+        tag:Safety .
+
+brick:First_Aid_Room a owl:Class ;
+    rdfs:label "First Aid Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:First ;
+                        owl:onProperty brick:hasTag ] _:has_Aid [ a owl:Restriction ;
+                        owl:hasValue tag:Meidcal ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Medical_Room ;
+    skos:definition "A room for a person with minor injuries can be treated or temporarily treated until transferred to a more advanced medical facility"@en ;
+    brick:hasAssociatedTag tag:Aid,
+        tag:First,
+        tag:Location,
+        tag:Meidcal,
+        tag:Room,
+        tag:Space .
+
+brick:Flow_Loss a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Flow Loss",
+        "FlowLoss" ;
+    qudt:applicableUnit unit:M3-PER-SEC ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L3I0M0H0T-1D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Flow ;
+    skos:definition "The amount of flow rate that is lost during distribution" .
+
+brick:Formaldehyde_Sensor a owl:Class ;
+    rdfs:label "Formaldehyde Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Particulate _:has_Matter [ a owl:Restriction ;
+                        owl:hasValue tag:Formaldehyde ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Particulate_Matter_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Formaldehyde_Concentration ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Formaldehyde,
+        tag:Matter,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor .
+
+brick:Freeze_Status a owl:Class ;
+    rdfs:label "Freeze Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Freeze _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if a substance contained within a vessel has frozen"@en ;
+    brick:hasAssociatedTag tag:Freeze,
+        tag:Point,
+        tag:Status .
+
+brick:Freezer a owl:Class ;
+    rdfs:label "Freezer" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Freezer ;
+                        owl:onProperty brick:hasTag ] _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    skos:definition "cold chamber usually kept at a temperature of 22°F to 31°F (–5°C to –1°C), with high-volume air circulation."@en ;
+    brick:hasAssociatedTag tag:Freezer,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
+
+brick:Fresh_Air_Fan a owl:Class ;
+    rdfs:label "Fresh Air Fan" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_Fresh _:has_Air ) ],
+        brick:Fan ;
+    skos:definition "Fan moving fresh air -- air that is supplied into the building from the outdoors"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Fan,
+        tag:Fresh .
+
+brick:Frost_Sensor a owl:Class ;
+    rdfs:label "Frost Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Frost ) ],
+        brick:Sensor,
+        brick:Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Frost ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Senses the presence of frost or conditions that may cause frost"@en ;
+    brick:hasAssociatedTag tag:Frost,
+        tag:Point,
+        tag:Sensor .
+
+brick:Fume_Hood a owl:Class ;
+    rdfs:label "Fume Hood" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fume _:has_Hood ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "A fume-collection device mounted over a work space, table, or shelf and serving to conduct unwanted gases away from the area enclosed."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fume,
+        tag:Hood .
+
+brick:Fume_Hood_Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Fume Hood Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fume _:has_Hood _:has_Air _:has_Flow _:has_Sensor ) ],
+        brick:Air_Flow_Sensor ;
+    skos:definition "Measures the rate of flow of air in a fume hood"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Fume,
+        tag:Hood,
+        tag:Point,
+        tag:Sensor .
+
+brick:Furniture a owl:Class ;
+    rdfs:label "Furniture" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Furniture> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Furniture ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Equipment ;
+    skos:definition "Movable objects intended to support various human activities such as seating, eating and sleeping"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Furniture .
+
+brick:Gas_Distribution a owl:Class ;
+    rdfs:label "Gas Distribution" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Gas _:has_Distribution _:has_Equipment ) ],
+        brick:Equipment ;
+    skos:definition "Utilize a gas distribution source to represent how gas is distributed across multiple destinations"@en ;
+    brick:hasAssociatedTag tag:Distribution,
+        tag:Equipment,
+        tag:Gas .
+
+brick:Gas_Sensor a owl:Class ;
+    rdfs:label "Gas Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Gas ) ],
+        brick:Sensor ;
+    skos:definition "Measures gas concentration (other than CO2)"@en ;
+    brick:hasAssociatedTag tag:Gas,
+        tag:Point,
+        tag:Sensor .
+
+brick:Gas_System a owl:Class ;
+    rdfs:label "Gas System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Gas _:has_System ) ],
+        brick:System ;
+    brick:hasAssociatedTag tag:Gas,
+        tag:System .
+
+brick:Gas_Valve a owl:Class ;
+    rdfs:label "Gas Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Gas _:has_Valve _:has_Equipment ) ],
+        brick:Valve ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Gas,
+        tag:Valve .
+
+brick:Gatehouse a owl:Class ;
+    rdfs:label "Gatehouse" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Gatehouse ;
+                        owl:onProperty brick:hasTag ] _:has_Space _:has_Location ) ],
+        brick:Space ;
+    skos:definition "The standalone building used to manage the entrance to a campus or building grounds"@en ;
+    brick:hasAssociatedTag tag:Gatehouse,
+        tag:Location,
+        tag:Space .
+
+brick:Generator_Room a owl:Class ;
+    rdfs:label "Generator Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Generator _:has_Electrical _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Electrical_Room ;
+    skos:definition "A room for electrical equipment, specifically electrical generators."@en ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Generator,
+        tag:Location,
+        tag:Room,
+        tag:Service,
+        tag:Space .
+
+brick:GrainsOfMoisture a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "GrainsOfMoisture" ;
+    qudt:applicableUnit unit:GRAIN ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M1H0T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Mass,
+        brick:Mass ;
+    skos:definition "Mass of moisture per pround of air, measured in grains of water" .
+
+brick:HVAC_Zone a owl:Class ;
+    rdfs:label "HVAC Zone" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_HVAC _:has_Zone _:has_Location ) ],
+        brick:Zone ;
+    skos:definition "a space or group of spaces, within a building with heating, cooling, and ventilating requirements, that are sufficiently similar so that desired conditions (e.g., temperature) can be maintained throughout using a single sensor (e.g., thermostat or temperature sensor)."@en ;
+    brick:hasAssociatedTag tag:HVAC,
+        tag:Location,
+        tag:Zone .
+
+brick:Hail_Sensor a owl:Class ;
+    rdfs:label "Hail Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Hail ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Hail ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures hail in terms of its size and damage potential"@en ;
+    brick:hasAssociatedTag tag:Hail,
+        tag:Point,
+        tag:Sensor .
+
+brick:Hallway a owl:Class ;
+    rdfs:label "Hallway" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Hallway ;
+                        owl:onProperty brick:hasTag ] _:has_Common _:has_Space _:has_Location ) ],
+        brick:Common_Space ;
+    skos:definition "A common space, used to connect other parts of a building"@en ;
+    brick:hasAssociatedTag tag:Common,
+        tag:Hallway,
+        tag:Location,
+        tag:Space .
+
+brick:Hazardous_Materials_Storage a owl:Class ;
+    rdfs:label "Hazardous Materials Storage" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Hazardous ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Materials ;
+                        owl:onProperty brick:hasTag ] _:has_Storage _:has_Room _:has_Space _:has_Location ) ],
+        brick:Storage_Room ;
+    skos:definition "A storage space set aside (usually with restricted access) for the storage of materials that can be hazardous to living beings or the environment"@en ;
+    brick:hasAssociatedTag tag:Hazardous,
+        tag:Location,
+        tag:Materials,
+        tag:Room,
+        tag:Space,
+        tag:Storage .
+
+brick:Heat_Exchanger_Supply_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Heat Exchanger Supply Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Exchanger _:has_Supply _:has_Water _:has_Temperature _:has_Sensor ) ],
+        brick:Water_Temperature_Sensor ;
+    skos:definition "Measures the temperature of water supplied by a heat exchanger"@en ;
+    brick:hasAssociatedTag tag:Exchanger,
+        tag:Heat,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Heat_Exchanger_System_Enable_Status a owl:Class ;
+    rdfs:label "Heat Exchanger System Enable Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Exchanger _:has_System _:has_Enable _:has_Status ) ],
+        brick:Enable_Status,
+        brick:System_Status ;
+    skos:definition "Indicates if the heat exchanger system has been enabled"@en ;
+    brick:hasAssociatedTag tag:Enable,
+        tag:Exchanger,
+        tag:Heat,
+        tag:Point,
+        tag:Status,
+        tag:System .
+
+brick:Heat_Recovery_Hot_Water_System a owl:Class ;
+    rdfs:label "Heat Recovery Hot Water System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_System _:has_Heat [ a owl:Restriction ;
+                        owl:hasValue tag:Recovery ;
+                        owl:onProperty brick:hasTag ] _:has_System ) ],
+        brick:Hot_Water_System ;
+    brick:hasAssociatedTag tag:Heat,
+        tag:Hot,
+        tag:Recovery,
+        tag:System,
+        tag:Water .
+
+brick:Heat_Wheel a owl:Class ;
+    rdfs:label "Heat Wheel" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Thermal_wheel> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Heat _:has_Wheel ) ],
+        brick:Heat_Exchanger ;
+    skos:definition "A rotary heat exchanger positioned within the supply and exhaust air streams of an air handling system in order to recover heat energy"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heat,
+        tag:Wheel .
+
+brick:Heat_Wheel_VFD a owl:Class ;
+    rdfs:label "Heat Wheel VFD" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Heat _:has_Wheel _:has_VFD ) ],
+        brick:VFD ;
+    skos:definition "A VFD that drives a heat wheel"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heat,
+        tag:VFD,
+        tag:Wheel .
+
+brick:Heating_Command a owl:Class ;
+    rdfs:label "Heating Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls the amount of heating to be delivered (typically as a proportion of total heating output)"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Heat,
+        tag:Point .
+
+brick:Heating_Demand_Setpoint a owl:Class ;
+    rdfs:label "Heating Demand Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Demand _:has_Setpoint ) ],
+        brick:Demand_Setpoint ;
+    skos:definition "Sets the rate required for heating"@en ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Heating_Start_Stop_Status a owl:Class ;
+    rdfs:label "Heating Start Stop Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Start _:has_Stop _:has_Status ) ],
+        brick:Start_Stop_Status ;
+    brick:hasAssociatedTag tag:Heat,
+        tag:Point,
+        tag:Start,
+        tag:Status,
+        tag:Stop .
+
+brick:Heating_Supply_Air_Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Heating Supply Air Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Heating_Temperature_Setpoint,
+        brick:Supply_Air_Temperature_Deadband_Setpoint ;
+    owl:equivalentClass brick:Heating_Discharge_Air_Temperature_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature of supply air for heating"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Deadband,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Heating_Supply_Air_Temperature_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Heating Supply Air Temperature Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Supply _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Air_Temperature_Integral_Time_Parameter ;
+    owl:equivalentClass brick:Heating_Discharge_Air_Temperature_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Supply,
+        tag:Temperature,
+        tag:Time .
+
+brick:Heating_Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Heating Supply Air Temperature Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Supply_Air_Temperature_Proportional_Band_Parameter ;
+    owl:equivalentClass brick:Heating_Discharge_Air_Temperature_Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:Heat,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Heating_Thermal_Power_Sensor a owl:Class ;
+    rdfs:label "Heating Thermal Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Sensor _:has_Power _:has_Thermal ) ],
+        brick:Thermal_Power_Sensor ;
+    brick:hasAssociatedTag tag:Heat,
+        tag:Point,
+        tag:Power,
+        tag:Sensor,
+        tag:Thermal .
+
+brick:High_CO2_Alarm a owl:Class ;
+    rdfs:label "High CO2 Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_CO2 _:has_Alarm ) ],
+        brick:CO2_Alarm ;
+    skos:definition "A device that indicates high concentration of carbon dioxide."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:CO2,
+        tag:High,
+        tag:Point .
+
+brick:High_Discharge_Air_Temperature_Alarm a owl:Class ;
+    rdfs:label "High Discharge Air Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
+        brick:Discharge_Air_Temperature_Alarm,
+        brick:High_Temperature_Alarm ;
+    skos:definition "An alarm that indicates that discharge air temperature is too high"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Discharge,
+        tag:High,
+        tag:Point,
+        tag:Temperature .
+
+brick:High_Head_Pressure_Alarm a owl:Class ;
+    rdfs:label "High Head Pressure Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High [ a owl:Restriction ;
+                        owl:hasValue tag:Head ;
+                        owl:onProperty brick:hasTag ] _:has_Pressure _:has_Alarm ) ],
+        brick:Pressure_Alarm ;
+    skos:definition "An alarm that indicates a high pressure generated on the output side of a gas compressor in a refrigeration or air conditioning system."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Head,
+        tag:High,
+        tag:Point,
+        tag:Pressure .
+
+brick:High_Humidity_Alarm a owl:Class ;
+    rdfs:label "High Humidity Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Humidity _:has_Alarm ) ],
+        brick:Humidity_Alarm ;
+    skos:definition "An alarm that indicates high concentration of water vapor in the air."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:High,
+        tag:Humidity,
+        tag:Point .
+
+brick:High_Humidity_Alarm_Parameter a owl:Class ;
+    rdfs:label "High Humidity Alarm Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Humidity _:has_Alarm _:has_Parameter ) ],
+        brick:Humidity_Parameter ;
+    skos:definition "A parameter determining the humidity level at which to trigger a high humidity alarm"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:High,
+        tag:Humidity,
+        tag:Parameter,
+        tag:Point .
+
+brick:High_Outside_Air_Lockout_Temperature_Differential_Parameter a owl:Class ;
+    rdfs:label "High Outside Air Lockout Temperature Differential Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Parameter ) ],
+        brick:Outside_Air_Lockout_Temperature_Differential_Parameter ;
+    skos:definition "The upper bound of the outside air temperature lockout range"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:High,
+        tag:Lockout,
+        tag:Outside,
+        tag:Parameter,
+        tag:Point,
+        tag:Temperature .
+
+brick:High_Return_Air_Temperature_Alarm a owl:Class ;
+    rdfs:label "High Return Air Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
+        brick:High_Temperature_Alarm,
+        brick:Return_Air_Temperature_Alarm ;
+    skos:definition "An alarm that indicates that return air temperature is too high"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:High,
+        tag:Point,
+        tag:Return,
+        tag:Temperature .
+
+brick:High_Static_Pressure_Cutout_Setpoint_Limit a owl:Class ;
+    rdfs:label "High Static Pressure Cutout Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Static _:has_Pressure [ a owl:Restriction ;
+                        owl:hasValue tag:Cutout ;
+                        owl:onProperty brick:hasTag ] _:has_Limit _:has_Setpoint ) ],
+        brick:Static_Pressure_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a High_Static_Pressure_Cutout_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Cutout,
+        tag:High,
+        tag:Limit,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:High_Temperature_Alarm_Parameter a owl:Class ;
+    rdfs:label "High Temperature Alarm Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Temperature _:has_Alarm _:has_Parameter ) ],
+        brick:Temperature_Parameter ;
+    skos:definition "A parameter determining the temperature level at which to trigger a high temperature alarm"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:High,
+        tag:Parameter,
+        tag:Point,
+        tag:Temperature .
+
+brick:High_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
+    rdfs:label "High Temperature Hot Water Return Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+        brick:Hot_Water_Return_Temperature_Sensor ;
+    skos:definition "Measures the temperature of high-temperature hot water returned to a hot water system"@en ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:High_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
+    rdfs:label "High Temperature Hot Water Supply Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+        brick:Hot_Water_Supply_Temperature_Sensor ;
+    skos:definition "Measures the temperature of high-temperature hot water supplied by a hot water system"@en ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Hold_Status a owl:Class ;
+    rdfs:label "Hold Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Hold ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+        brick:Status ;
+    brick:hasAssociatedTag tag:Hold,
+        tag:Point,
+        tag:Status .
+
+brick:Hospitality_Box a owl:Class ;
+    rdfs:label "Hospitality Box" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Hospitality ;
+                        owl:onProperty brick:hasTag ] _:has_Box _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A room at a stadium, usually overlooking the field of play, that is physical separate from the other seating at the venue"@en ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Hospitality,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Hot_Box a owl:Class ;
+    rdfs:label "Hot Box" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Box _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Laboratory ;
+    skos:definition "hot air chamber forming part of an air handler."@en ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Hot,
+        tag:Laboratory,
+        tag:Location,
+        tag:Room .
+
+brick:Hot_Water_Baseboard_Radiator a owl:Class ;
+    rdfs:label "Hot Water Baseboard Radiator" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Radiator _:has_Hot _:has_Water _:has_Baseboard ) ],
+        brick:Baseboard_Radiator,
+        brick:Hot_Water_Radiator ;
+    skos:definition "Hydronic heating device located at or near the floor"@en ;
+    brick:hasAssociatedTag tag:Baseboard,
+        tag:Equipment,
+        tag:Hot,
+        tag:Radiator,
+        tag:Water .
+
+brick:Hot_Water_Coil a owl:Class ;
+    rdfs:label "Hot Water Coil" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Coil _:has_Hot _:has_Water ) ],
+        brick:Heating_Coil ;
+    skos:definition "A heating element typically made of pipe, tube or wire that emits heat that is filled with hot water."@en ;
+    brick:hasAssociatedTag tag:Coil,
+        tag:Equipment,
+        tag:Hot,
+        tag:Water .
+
+brick:Hot_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Hot Water Differential Pressure Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+        brick:Differential_Pressure_Deadband_Setpoint,
+        brick:Hot_Water_Differential_Pressure_Setpoint ;
+    skos:definition "Sets the size of a deadband of differential pressure of hot water"@en ;
+    brick:hasAssociatedTag tag:Deadband,
+        tag:Differential,
+        tag:Hot,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Hot_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Hot Water Differential Pressure Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Differential_Pressure_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Time,
+        tag:Water .
+
+brick:Hot_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
+    rdfs:label "Hot Water Differential Pressure Load Shed Reset Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+        brick:Hot_Water_Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Load,
+        tag:Point,
+        tag:Pressure,
+        tag:Reset,
+        tag:Shed,
+        tag:Status,
+        tag:Water .
+
+brick:Hot_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Hot Water Differential Pressure Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Differential_Pressure_Proportional_Band ;
+    brick:hasAssociatedTag tag:Band,
+        tag:Differential,
+        tag:Hot,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Proportional,
+        tag:Water .
+
+brick:Hot_Water_Discharge_Temperature_Load_Shed_Status a owl:Class ;
+    rdfs:label "Hot Water Discharge Temperature Load Shed Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Hot,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Status,
+        tag:Temperature,
+        tag:Water .
+
+brick:Hot_Water_Flow_Sensor a owl:Class ;
+    rdfs:label "Hot Water Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Hot ) ],
+        brick:Water_Flow_Sensor ;
+    skos:definition "Measures the rate of flow of hot water"@en ;
+    brick:hasAssociatedTag tag:Flow,
+        tag:Hot,
+        tag:Point,
+        tag:Sensor,
+        tag:Water .
+
+brick:Hot_Water_Pump a owl:Class ;
+    rdfs:label "Hot Water Pump" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Hot _:has_Water ) ],
+        brick:Water_Pump ;
+    skos:definition "A pump that performs work on hot water; typically part of a hot water system"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Hot,
+        tag:Pump,
+        tag:Water .
+
+brick:Hot_Water_Static_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Hot Water Static Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Static _:has_Pressure _:has_Setpoint ) ],
+        brick:Static_Pressure_Setpoint ;
+    skos:definition "Sets static pressure of hot air"@en ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static,
+        tag:Water .
+
+brick:Hot_Water_Usage_Sensor a owl:Class ;
+    rdfs:label "Hot Water Usage Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage _:has_Hot _:has_Water ) ],
+        brick:Water_Usage_Sensor ;
+    skos:definition "Measures the amount of hot water that is consumed, over some period of time"@en ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Point,
+        tag:Sensor,
+        tag:Usage,
+        tag:Water .
+
+brick:Humidification_Start_Stop_Status a owl:Class ;
+    rdfs:label "Humidification Start Stop Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Humidification ;
+                        owl:onProperty brick:hasTag ] _:has_Start _:has_Stop _:has_Status ) ],
+        brick:Start_Stop_Status ;
+    brick:hasAssociatedTag tag:Humidification,
+        tag:Point,
+        tag:Start,
+        tag:Status,
+        tag:Stop .
+
+brick:Humidifier a owl:Class ;
+    rdfs:label "Humidifier" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Humidifier ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "A device that adds moisture to air or other gases"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Humidifier .
+
+brick:Humidifier_Fault_Status a owl:Class ;
+    rdfs:label "Humidifier Fault Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidifier _:has_Fault _:has_Status ) ],
+        brick:Fault_Status ;
+    skos:definition "Indicates the presence of a fault in a humidifier"@en ;
+    brick:hasAssociatedTag tag:Fault,
+        tag:Humidifier,
+        tag:Point,
+        tag:Status .
+
+brick:Humidify_Command a owl:Class ;
+    rdfs:label "Humidify Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Humidify ;
+                        owl:onProperty brick:hasTag ] _:has_Command ) ],
+        brick:Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Humidify,
+        tag:Point .
+
+brick:Humidity_Tolerance_Parameter a owl:Class ;
+    rdfs:label "Humidity Tolerance Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Tolerance _:has_Parameter _:has_Humidity ) ],
+        brick:Humidity_Parameter,
+        brick:Tolerance_Parameter ;
+    skos:definition "A parameter determining the difference between upper and lower limits of humidity."@en ;
+    brick:hasAssociatedTag tag:Humidity,
+        tag:Parameter,
+        tag:Point,
+        tag:Tolerance .
+
+brick:IDF a owl:Class ;
+    rdfs:label "IDF" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:IDF ;
+                        owl:onProperty brick:hasTag ] _:has_Distribution _:has_Frame _:has_Telecom _:has_Room _:has_Space _:has_Location ) ],
+        brick:Distribution_Frame ;
+    skos:definition "An room for an intermediate distribution frame, where cables carrying signals from the main distrubtion frame terminate and then feed out to endpoints"@en ;
+    brick:hasAssociatedTag tag:Distribution,
+        tag:Frame,
+        tag:IDF,
+        tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:Telecom .
+
+brick:Ice_Tank_Leaving_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Ice Tank Leaving Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Ice _:has_Tank _:has_Leaving _:has_Water _:has_Temperature _:has_Sensor ) ],
+        brick:Leaving_Water_Temperature_Sensor ;
+    skos:definition "Measures the temperature of water leaving an ice tank"@en ;
+    brick:hasAssociatedTag tag:Ice,
+        tag:Leaving,
+        tag:Point,
+        tag:Sensor,
+        tag:Tank,
+        tag:Temperature,
+        tag:Water .
+
+brick:Information_Area a owl:Class ;
+    rdfs:label "Information Area" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Location _:has_Outdoor _:has_Area [ a owl:Restriction ;
+                        owl:hasValue tag:Information ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Outdoor_Area ;
+    skos:definition "An information booth or kiosk where visitors would look for information"@en ;
+    brick:hasAssociatedTag tag:Area,
+        tag:Information,
+        tag:Location,
+        tag:Outdoor .
+
+brick:Intake_Air_Filter a owl:Class ;
+    rdfs:label "Intake Air Filter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Intake _:has_Air _:has_Filter ) ],
+        brick:Filter ;
+    skos:definition "Filters air intake"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Filter,
+        tag:Intake .
+
+brick:Intake_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Intake Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Intake _:has_Sensor ) ],
+        brick:Outside_Air_Temperature_Sensor ;
+    skos:definition "Measures air at the interface between the building and the outside"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Intake,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Intrusion_Detection_Equipment a owl:Class ;
+    rdfs:label "Intrusion Detection Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Security [ a owl:Restriction ;
+                        owl:hasValue tag:Intrusion ;
+                        owl:onProperty brick:hasTag ] _:has_Detection ) ],
+        brick:Security_Equipment ;
+    brick:hasAssociatedTag tag:Detection,
+        tag:Equipment,
+        tag:Intrusion,
+        tag:Security .
+
+brick:Inverter a owl:Class ;
+    rdfs:label "Inverter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Inverter ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Electrical_Equipment ;
+    skos:definition "A device that changes direct current into alternating current"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Inverter .
+
+brick:Janitor_Room a owl:Class ;
+    rdfs:label "Janitor Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Janitor ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A room set aside for the storage of cleaning equipment and supplies"@en ;
+    brick:hasAssociatedTag tag:Janitor,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Last_Fault_Code_Status a owl:Class ;
+    rdfs:label "Last Fault Code Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Last ;
+                        owl:onProperty brick:hasTag ] _:has_Fault [ a owl:Restriction ;
+                        owl:hasValue tag:Code ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+        brick:Fault_Status ;
+    skos:definition "Indicates the last fault code that occurred"@en ;
+    brick:hasAssociatedTag tag:Code,
+        tag:Fault,
+        tag:Last,
+        tag:Point,
+        tag:Status .
+
+brick:Lead_Lag_Command a owl:Class ;
+    rdfs:label "Lead Lag Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lead _:has_Lag _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Enables lead/lag operation"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Lag,
+        tag:Lead,
+        tag:Point .
+
+brick:Lead_Lag_Status a owl:Class ;
+    rdfs:label "Lead Lag Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lead _:has_Lag _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if lead/lag operation is enabled"@en ;
+    brick:hasAssociatedTag tag:Lag,
+        tag:Lead,
+        tag:Point,
+        tag:Status .
+
+brick:Lead_On_Off_Command a owl:Class ;
+    rdfs:label "Lead On Off Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lead _:has_On _:has_Off _:has_Command ) ],
+        brick:On_Off_Command ;
+    skos:definition "Controls the active/inactive status of the \"lead\" part of a lead/lag system"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Lead,
+        tag:Off,
+        tag:On,
+        tag:Point .
+
+brick:Leaving_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Leaving Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Leaving _:has_Setpoint _:has_Temperature _:has_Water ) ],
+        brick:Water_Temperature_Setpoint ;
+    skos:definition "Sets temperature of leaving water"@en ;
+    brick:hasAssociatedTag tag:Leaving,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+brick:Library a owl:Class ;
+    rdfs:label "Library" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Library ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A place for the storage and/or consumption of physical media, e.g. books, periodicals, and DVDs/CDs"@en ;
+    brick:hasAssociatedTag tag:Library,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Lighting_System a owl:Class ;
+    rdfs:label "Lighting System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lighting _:has_System ) ],
+        brick:System ;
+    skos:definition "The equipment, devices and interfaces that serve or are a part of the lighting subsystem in a building"@en ;
+    brick:hasAssociatedTag tag:Lighting,
+        tag:System .
+
+brick:Lighting_Zone a owl:Class ;
+    rdfs:label "Lighting Zone" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lighting _:has_Zone _:has_Location ) ],
+        brick:Zone ;
+    brick:hasAssociatedTag tag:Lighting,
+        tag:Location,
+        tag:Zone .
+
+brick:Liquid_Detection_Alarm a owl:Class ;
+    rdfs:label "Liquid Detection Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Liquid _:has_Detection _:has_Alarm ) ],
+        brick:Alarm ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Detection,
+        tag:Liquid,
+        tag:Point .
+
+brick:Load_Current_Sensor a owl:Class ;
+    rdfs:label "Load Current Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Current _:has_Sensor ) ],
+        brick:Current_Sensor ;
+    skos:definition "Measures the current consumed by a load"@en ;
+    brick:hasAssociatedTag tag:Current,
+        tag:Load,
+        tag:Point,
+        tag:Sensor .
+
+brick:Loading_Dock a owl:Class ;
+    rdfs:label "Loading Dock" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Loading ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Dock ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A part of a facility where delivery trucks can load and unload. Usually partially enclosed with specific traffic lanes leading to the dock"@en ;
+    brick:hasAssociatedTag tag:Dock,
+        tag:Loading,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Locally_On_Off_Status a owl:Class ;
+    rdfs:label "Locally On Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Locally ;
+                        owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
+        brick:On_Off_Status ;
+    brick:hasAssociatedTag tag:Locally,
+        tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Status .
+
+brick:Louver a owl:Class ;
+    rdfs:label "Louver" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Shade _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Louver ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Equipment ;
+    skos:definition "Device consisting of an assembly of parallel sloping vanes, intended to permit the passage of air while providing a measure of protection against environmental influences"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Louver,
+        tag:Shade .
+
+brick:Low_Freeze_Protect_Temperature_Parameter a owl:Class ;
+    rdfs:label "Low Freeze Protect Temperature Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Freeze [ a owl:Restriction ;
+                        owl:hasValue tag:Protect ;
+                        owl:onProperty brick:hasTag ] _:has_Temperature _:has_Parameter ) ],
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Freeze,
+        tag:Low,
+        tag:Parameter,
+        tag:Point,
+        tag:Protect,
+        tag:Temperature .
+
+brick:Low_Humidity_Alarm a owl:Class ;
+    rdfs:label "Low Humidity Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Humidity _:has_Alarm ) ],
+        brick:Humidity_Alarm ;
+    skos:definition "An alarm that indicates low concentration of water vapor in the air."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Humidity,
+        tag:Low,
+        tag:Point .
+
+brick:Low_Humidity_Alarm_Parameter a owl:Class ;
+    rdfs:label "Low Humidity Alarm Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Humidity _:has_Alarm _:has_Parameter ) ],
+        brick:Humidity_Parameter ;
+    skos:definition "A parameter determining the humidity level at which to trigger a low humidity alarm"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Humidity,
+        tag:Low,
+        tag:Parameter,
+        tag:Point .
+
+brick:Low_Outside_Air_Lockout_Temperature_Differential_Parameter a owl:Class ;
+    rdfs:label "Low Outside Air Lockout Temperature Differential Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Parameter ) ],
+        brick:Outside_Air_Lockout_Temperature_Differential_Parameter ;
+    skos:definition "The lower bound of the outside air temperature lockout range"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Lockout,
+        tag:Low,
+        tag:Outside,
+        tag:Parameter,
+        tag:Point,
+        tag:Temperature .
+
+brick:Low_Outside_Air_Temperature_Enable_Differential_Sensor a owl:Class ;
+    rdfs:label "Low Outside Air Temperature Enable Differential Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
+        brick:Outside_Air_Temperature_Enable_Differential_Sensor ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Enable,
+        tag:Low,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Low_Outside_Air_Temperature_Enable_Setpoint a owl:Class ;
+    rdfs:label "Low Outside Air Temperature Enable Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Setpoint ) ],
+        brick:Outside_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Enable,
+        tag:Low,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Low_Return_Air_Temperature_Alarm a owl:Class ;
+    rdfs:label "Low Return Air Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
+        brick:Low_Temperature_Alarm,
+        brick:Return_Air_Temperature_Alarm ;
+    skos:definition "An alarm that indicates that return air temperature is too low"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Low,
+        tag:Point,
+        tag:Return,
+        tag:Temperature .
+
+brick:Low_Suction_Pressure_Alarm a owl:Class ;
+    rdfs:label "Low Suction Pressure Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low [ a owl:Restriction ;
+                        owl:hasValue tag:Suction ;
+                        owl:onProperty brick:hasTag ] _:has_Pressure _:has_Alarm ) ],
+        brick:Pressure_Alarm ;
+    skos:definition "An alarm that indicates a low suction pressure in the compressor in a refrigeration or air conditioning system."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Low,
+        tag:Point,
+        tag:Pressure,
+        tag:Suction .
+
+brick:Low_Temperature_Alarm_Parameter a owl:Class ;
+    rdfs:label "Low Temperature Alarm Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Temperature _:has_Alarm _:has_Parameter ) ],
+        brick:Temperature_Parameter ;
+    skos:definition "A parameter determining the temperature level at which to trigger a low temperature alarm"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Low,
+        tag:Parameter,
+        tag:Point,
+        tag:Temperature .
+
+brick:Lowest_Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
+    rdfs:label "Lowest Exhaust Air Static Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Lowest ;
+                        owl:onProperty brick:hasTag ] _:has_Exhaust _:has_Air _:has_Static _:has_Pressure _:has_Sensor ) ],
+        brick:Exhaust_Air_Static_Pressure_Sensor ;
+    skos:definition "The lowest observed static pressure of air in exhaust regions of an HVAC system over some period of time"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Lowest,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Static .
+
+brick:Luminaire a owl:Class ;
+    rdfs:label "Luminaire" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminaire _:has_Equipment ) ],
+        brick:Lighting ;
+    skos:definition "A complete lighting unit consisting of a lamp or lamps and ballast(s) (when applicable) together with the parts designed to distribute the light, to position and protect the lamps, and to connect the lamps to the power supply."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Luminaire .
+
+brick:Luminaire_Driver a owl:Class ;
+    rdfs:label "Luminaire Driver" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Luminaire [ a owl:Restriction ;
+                        owl:hasValue tag:Driver ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Lighting ;
+    skos:definition "A power source for a luminaire"@en ;
+    brick:hasAssociatedTag tag:Driver,
+        tag:Equipment,
+        tag:Luminaire .
+
+brick:Luminance_Alarm a owl:Class ;
+    rdfs:label "Luminance Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Luminance _:has_Alarm ) ],
+        brick:Alarm ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Luminance,
+        tag:Point .
+
+brick:Luminance_Command a owl:Class ;
+    rdfs:label "Luminance Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Luminance _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls the amount of luminance delivered by a lighting system"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Luminance,
+        tag:Point .
+
+brick:Luminance_Sensor a owl:Class ;
+    rdfs:label "Luminance Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Luminance ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Luminance ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the luminous intensity per unit area of light travelling in a given direction"@en ;
+    brick:hasAssociatedTag tag:Luminance,
+        tag:Point,
+        tag:Sensor .
+
+brick:Luminance_Setpoint a owl:Class ;
+    rdfs:label "Luminance Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Luminance _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets luminance"@en ;
+    brick:hasAssociatedTag tag:Luminance,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Luminous_Flux a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Luminous Flux" ;
+    qudt:applicableUnit unit:LM ;
+    owl:sameAs qudtqk:LuminousFlux ;
+    skos:broader brick:Luminance .
+
+brick:Luminous_Intensity a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Luminous Intensity" ;
+    qudt:applicableUnit unit:CD,
+        unit:CP ;
+    owl:sameAs qudtqk:LuminousIntensity ;
+    skos:broader brick:Luminance .
+
+brick:MDF a owl:Class ;
+    rdfs:label "MDF" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:MDF ;
+                        owl:onProperty brick:hasTag ] _:has_Distribution _:has_Frame _:has_Telecom _:has_Room _:has_Space _:has_Location ) ],
+        brick:Distribution_Frame ;
+    skos:definition "A room for the Main Distribution Frame, the central place of a building where cables carrying signals meet and connect to the outside world"@en ;
+    brick:hasAssociatedTag tag:Distribution,
+        tag:Frame,
+        tag:Location,
+        tag:MDF,
+        tag:Room,
+        tag:Space,
+        tag:Telecom .
+
+brick:Mail_Room a owl:Class ;
+    rdfs:label "Mail Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Mail ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A room where mail is recieved and sorted for distribution to the rest of the building"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Mail,
+        tag:Room,
+        tag:Space .
+
+brick:Maintenance_Mode_Command a owl:Class ;
+    rdfs:label "Maintenance Mode Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Maintenance _:has_Mode _:has_Command ) ],
+        brick:Mode_Command ;
+    skos:definition "Controls whether or not a device or controller is operating in \"Maintenance\" mode"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Maintenance,
+        tag:Mode,
+        tag:Point .
+
+brick:Maintenance_Required_Alarm a owl:Class ;
+    rdfs:label "Maintenance Required Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Maintenance [ a owl:Restriction ;
+                        owl:hasValue tag:Required ;
+                        owl:onProperty brick:hasTag ] _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates that repair/maintenance is required on an associated device or equipment"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Maintenance,
+        tag:Point,
+        tag:Required .
+
+brick:Majlis a owl:Class ;
+    rdfs:label "Majlis" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lounge _:has_Common _:has_Space _:has_Location ) ],
+        brick:Lounge ;
+    skos:definition "In Arab countries, an Majlis is a private lounge where visitors are recieved and entertained"@en ;
+    brick:hasAssociatedTag tag:Common,
+        tag:Location,
+        tag:Lounge,
+        tag:Space .
+
+brick:Makeup_Water_Valve a owl:Class ;
+    rdfs:label "Makeup Water Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Makeup _:has_Valve _:has_Equipment ) ],
+        brick:Water_Valve ;
+    skos:definition "A valve regulating the flow of makeup water into a water holding tank, e.g. a cooling tower, hot water tank"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Makeup,
+        tag:Valve,
+        tag:Water .
+
+brick:Manual_Auto_Status a owl:Class ;
+    rdfs:label "Manual Auto Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Manual ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Auto ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if a system is under manual or automatic operation"@en ;
+    brick:hasAssociatedTag tag:Auto,
+        tag:Manual,
+        tag:Point,
+        tag:Status .
+
+brick:Massage_Room a owl:Class ;
+    rdfs:label "Massage Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Massage _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "Usually adjunct to an athletic facility, a private/semi-private space where massages are performed"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Massage,
+        tag:Room,
+        tag:Space .
+
+brick:Max_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Max Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Setpoint for maximum air temperature"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Max,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Max_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Chilled Water Differential Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Differential_Pressure_Setpoint_Limit,
+        brick:Max_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Chilled_Water_Differential_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Max_Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Discharge Air Temperature Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Setpoint_Limit,
+        brick:Max_Temperature_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Discharge_Air_Temperature_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Limit,
+        tag:Max,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Max_Frequency_Command a owl:Class ;
+    rdfs:label "Max Frequency Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Fequency _:has_Command ) ],
+        brick:Frequency_Command ;
+    skos:definition "Sets the maximum permitted frequency"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Fequency,
+        tag:Max,
+        tag:Point .
+
+brick:Max_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Hot Water Differential Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Differential_Pressure_Setpoint_Limit,
+        brick:Max_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Hot_Water_Differential_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Max_Load_Setpoint a owl:Class ;
+    rdfs:label "Max Load Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Load _:has_Parameter _:has_Setpoint ) ],
+        brick:Load_Parameter ;
+    brick:hasAssociatedTag tag:Load,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Max_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Occupied Cooling Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Cool _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Occupied_Cooling_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Flow,
+        tag:Limit,
+        tag:Max,
+        tag:Occupied,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Max_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Occupied Heating Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Heat _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Occupied_Heating_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Max,
+        tag:Occupied,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Max_Position_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Position Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Position _:has_Limit _:has_Setpoint ) ],
+        brick:Max_Limit,
+        brick:Position_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Position_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Max,
+        tag:Point,
+        tag:Position,
+        tag:Setpoint .
+
+brick:Max_Speed_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Speed Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Limit,
+        brick:Speed_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Speed_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Speed .
+
+brick:Max_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Supply Air Static Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Limit,
+        brick:Max_Static_Pressure_Setpoint_Limit ;
+    owl:equivalentClass brick:Max_Discharge_Air_Static_Pressure_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Supply_Air_Static_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static,
+        tag:Supply .
+
+brick:Max_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Unoccupied Cooling Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Cool _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Unoccupied_Cooling_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Flow,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Unoccupied .
+
+brick:Max_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Unoccupied Heating Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Heat _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Unoccupied_Heating_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Unoccupied .
+
+brick:Max_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Max Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Water _:has_Temperature _:has_Setpoint ) ],
+        brick:Water_Temperature_Setpoint ;
+    skos:definition "Setpoint for max water temperature"@en ;
+    brick:hasAssociatedTag tag:Max,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+brick:Media_Hot_Desk a owl:Class ;
+    rdfs:label "Media Hot Desk" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Media [ a owl:Restriction ;
+                        owl:hasValue tag:Desk ;
+                        owl:onProperty brick:hasTag ] _:has_Space _:has_Location ) ],
+        brick:Space ;
+    skos:definition "A non-enclosed space used by members of the media temporarily to cover an event while they are present at a venue"@en ;
+    brick:hasAssociatedTag tag:Desk,
+        tag:Location,
+        tag:Media,
+        tag:Space .
+
+brick:Media_Production_Room a owl:Class ;
+    rdfs:label "Media Production Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Production ;
+                        owl:onProperty brick:hasTag ] _:has_Media _:has_Room _:has_Space _:has_Location ) ],
+        brick:Media_Room ;
+    skos:definition "A enclosed space used by media professionals for the production of media"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Media,
+        tag:Production,
+        tag:Room,
+        tag:Space .
+
+brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Reset_Status a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Reset Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Reset _:has_Status ) ],
+        brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Reset,
+        tag:Shed,
+        tag:Status,
+        tag:Temperature .
+
+brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Setpoint a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
+        brick:Load_Shed_Setpoint ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Shed,
+        tag:Temperature,
+        tag:Water .
+
+brick:Medium_Temperature_Hot_Water_Differential_Pressure_Sensor a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Differential Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
+        brick:Hot_Water_Differential_Pressure_Sensor ;
+    skos:definition "Measures the difference in water pressure between sections of a medium temperature hot water system"@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Medium_Temperature_Hot_Water_Discharge_Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Discharge Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:High,
+        tag:Hot,
+        tag:Medium,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+brick:Medium_Temperature_Hot_Water_Discharge_Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Discharge Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Discharge _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Hot,
+        tag:Low,
+        tag:Medium,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+brick:Medium_Temperature_Hot_Water_Return_Temperature_Sensor a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Return Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+        brick:Hot_Water_Return_Temperature_Sensor ;
+    skos:definition "Measures the temperature of medium-temperature hot water returned to a hot water system"@en ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Medium,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Medium_Temperature_Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Supply Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Medium,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Setpoint a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Supply Temperature Load Shed Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Pressure _:has_Shed _:has_Load _:has_Setpoint ) ],
+        brick:Load_Shed_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Shed,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Medium_Temperature_Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Supply Temperature Load Shed Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Hot_Water_Supply_Temperature_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Shed,
+        tag:Status,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Medium_Temperature_Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Supply Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Low,
+        tag:Medium,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Medium_Temperature_Hot_Water_Supply_Temperature_Sensor a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Supply Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Sensor ) ],
+        brick:Hot_Water_Supply_Temperature_Sensor ;
+    skos:definition "Measures the temperature of medium-temperature hot water supplied by a hot water system"@en ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Medium,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Min_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Min Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Setpoint for minimum air temperature"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Min,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Min_Chilled_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Chilled Water Differential Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Differential_Pressure_Setpoint_Limit,
+        brick:Min_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Chilled_Water_Differential_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Min_Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Discharge Air Temperature Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Setpoint_Limit,
+        brick:Min_Temperature_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Discharge_Air_Temperature_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Limit,
+        tag:Min,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Min_Fresh_Air_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Fresh Air Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
+        brick:Fresh_Air_Setpoint_Limit,
+        brick:Min_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Fresh_Air_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Fresh,
+        tag:Limit,
+        tag:Min,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Min_Hot_Water_Differential_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Hot Water Differential Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Differential_Pressure_Setpoint_Limit,
+        brick:Min_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Hot_Water_Differential_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Min_Occupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Occupied Cooling Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Cool _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Occupied_Cooling_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Flow,
+        tag:Limit,
+        tag:Min,
+        tag:Occupied,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Min_Occupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Occupied Heating Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Heat _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Occupied_Heating_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Min,
+        tag:Occupied,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Min_Outside_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Outside Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Outside _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Outside_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Limit,
+        tag:Min,
+        tag:Outside,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Min_Position_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Position Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Position _:has_Limit _:has_Setpoint ) ],
+        brick:Min_Limit,
+        brick:Position_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Position_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Min,
+        tag:Point,
+        tag:Position,
+        tag:Setpoint .
+
+brick:Min_Speed_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Speed Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Limit,
+        brick:Speed_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Speed_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Speed .
+
+brick:Min_Supply_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Supply Air Static Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Limit,
+        brick:Min_Static_Pressure_Setpoint_Limit ;
+    owl:equivalentClass brick:Min_Discharge_Air_Static_Pressure_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Supply_Air_Static_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static,
+        tag:Supply .
+
+brick:Min_Unoccupied_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Unoccupied Cooling Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Cool _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Unoccupied_Cooling_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Flow,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Unoccupied .
+
+brick:Min_Unoccupied_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Unoccupied Heating Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Heat _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Unoccupied_Heating_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Unoccupied .
+
+brick:Min_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Min Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Water _:has_Temperature _:has_Setpoint ) ],
+        brick:Water_Temperature_Setpoint ;
+    skos:definition "Setpoint for min water temperature"@en ;
+    brick:hasAssociatedTag tag:Min,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+brick:Mixed_Air_Filter a owl:Class ;
+    rdfs:label "Mixed Air Filter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Mixed _:has_Air _:has_Filter ) ],
+        brick:Filter ;
+    skos:definition "A filter that is applied to the mixture of recirculated and outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Filter,
+        tag:Mixed .
+
+brick:Mixed_Air_Humidity_Sensor a owl:Class ;
+    rdfs:label "Mixed Air Humidity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Relative _:has_Air _:has_Mixed ) ],
+        brick:Relative_Humidity_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Relative_Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Mixed_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the humidity of mixed air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Mixed,
+        tag:Point,
+        tag:Relative,
+        tag:Sensor .
+
+brick:Mixed_Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Mixed Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air _:has_Mixed ) ],
+        brick:Air_Humidity_Setpoint ;
+    skos:definition "Humidity setpoint for mixed air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Mixed,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Mixed_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Mixed Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Mixed ) ],
+        brick:Air_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Mixed_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of mixed air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Mixed,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Mixed_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Mixed Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mixed _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of mixed air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Mixed,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Mixed_Damper a owl:Class ;
+    rdfs:label "Mixed Damper" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper _:has_Mixed ) ],
+        brick:Damper ;
+    skos:definition "A damper that modulates the flow of the mixed outside and return air streams"@en ;
+    brick:hasAssociatedTag tag:Damper,
+        tag:Equipment,
+        tag:Mixed .
+
+brick:Motor_Control_Center a owl:Class ;
+    rdfs:label "Motor Control Center" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Control [ a owl:Restriction ;
+                        owl:hasValue tag:Center ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Electrical_Equipment ;
+    skos:definition "The Motor Control Center is a specialized type of switchgear which provides electrical power to major mechanical systems in the building such as HVAC components."@en ;
+    brick:hasAssociatedTag tag:Center,
+        tag:Control,
+        tag:Equipment .
+
+brick:Motor_Current_Sensor a owl:Class ;
+    rdfs:label "Motor Current Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Current _:has_Sensor ) ],
+        brick:Current_Sensor ;
+    skos:definition "Measures the current consumed by a motor"@en ;
+    brick:hasAssociatedTag tag:Current,
+        tag:Motor,
+        tag:Point,
+        tag:Sensor .
+
+brick:Motor_Direction_Status a owl:Class ;
+    rdfs:label "Motor Direction Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Direction _:has_Status ) ],
+        brick:Direction_Status ;
+    skos:definition "Indicates which direction a motor is operating in, e.g. forward or reverse"@en ;
+    brick:hasAssociatedTag tag:Direction,
+        tag:Motor,
+        tag:Point,
+        tag:Status .
+
+brick:Motor_On_Off_Status a owl:Class ;
+    rdfs:label "Motor On Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_On _:has_Off _:has_Status ) ],
+        brick:On_Off_Status ;
+    brick:hasAssociatedTag tag:Motor,
+        tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Status .
+
+brick:Motor_Speed_Sensor a owl:Class ;
+    rdfs:label "Motor Speed Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Speed _:has_Sensor ) ],
+        brick:Speed_Sensor ;
+    brick:hasAssociatedTag tag:Motor,
+        tag:Point,
+        tag:Sensor,
+        tag:Speed .
+
+brick:Motor_Torque_Sensor a owl:Class ;
+    rdfs:label "Motor Torque Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Motor _:has_Torque _:has_Sensor ) ],
+        brick:Torque_Sensor ;
+    skos:definition "Measures the torque, or rotating power, of a motor"@en ;
+    brick:hasAssociatedTag tag:Motor,
+        tag:Point,
+        tag:Sensor,
+        tag:Torque .
+
+brick:No_Water_Alarm a owl:Class ;
+    rdfs:label "No Water Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:No ;
+                        owl:onProperty brick:hasTag ] _:has_Water _:has_Alarm ) ],
+        brick:Water_Alarm ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:No,
+        tag:Point,
+        tag:Water .
+
+brick:Occupancy_Command a owl:Class ;
+    rdfs:label "Occupancy Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupancy _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls whether or not a device or controller is operating in \"Occupied\" mode"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Occupancy,
+        tag:Point .
+
+brick:Occupancy_Count a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Occupancy Count",
+        "Occupancy_Count" ;
+    qudt:applicableUnit unit:People ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Occupancy ;
+    skos:definition "Number of people in an area",
+        "Number of people in an area"@en .
+
+brick:Occupancy_Percentage a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Occupancy Percentage",
+        "Occupancy_Percentage" ;
+    qudt:applicableUnit unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Occupancy ;
+    skos:definition "Percent of total occupancy of space that is occupied",
+        "Percent of total occupancy of space that is occupied"@en .
+
+brick:Occupied_Cooling_Supply_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Occupied Cooling Supply Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cool _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Cooling_Supply_Air_Flow_Setpoint,
+        brick:Occupied_Supply_Air_Flow_Setpoint ;
+    owl:equivalentClass brick:Occupied_Cooling_Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets supply air flow rate for cooling when occupied"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Flow,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Occupied_Cooling_Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Occupied Cooling Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cool _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Cooling_Temperature_Setpoint,
+        brick:Temperature_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature for cooling when occupied"@en ;
+    brick:hasAssociatedTag tag:Cool,
+        tag:Deadband,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Occupied_Discharge_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Occupied Discharge Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Occupied ) ],
+        brick:Discharge_Air_Temperature_Setpoint,
+        brick:Occupied_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Heat,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Occupied_Heating_Supply_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Occupied Heating Supply Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Heat _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Heating_Supply_Air_Flow_Setpoint,
+        brick:Occupied_Supply_Air_Flow_Setpoint ;
+    owl:equivalentClass brick:Occupied_Heating_Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets supply air flow rate for heating when occupied"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Heat,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Occupied_Heating_Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Occupied Heating Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Heat _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Heating_Temperature_Setpoint,
+        brick:Temperature_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature for heating when occupied"@en ;
+    brick:hasAssociatedTag tag:Deadband,
+        tag:Heat,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Occupied_Mode_Status a owl:Class ;
+    rdfs:label "Occupied Mode Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Mode _:has_Status ) ],
+        brick:Mode_Status ;
+    skos:definition "Indicates if a system, device or control loop is in \"Occupied\" mode"@en ;
+    brick:hasAssociatedTag tag:Mode,
+        tag:Occupied,
+        tag:Point,
+        tag:Status .
+
+brick:Occupied_Return_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Occupied Return Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Occupied ) ],
+        brick:Occupied_Air_Temperature_Setpoint,
+        brick:Return_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Occupied,
+        tag:Point,
+        tag:Return,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Occupied_Room_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Occupied Room Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Room _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Occupied ) ],
+        brick:Occupied_Air_Temperature_Setpoint,
+        brick:Room_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Occupied,
+        tag:Point,
+        tag:Room,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Occupied_Supply_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Occupied Supply Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Occupied ) ],
+        brick:Occupied_Air_Temperature_Setpoint,
+        brick:Supply_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Occupied_Zone_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Occupied Zone Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Occupied ) ],
+        brick:Occupied_Air_Temperature_Setpoint,
+        brick:Zone_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Zone .
+
+brick:Off_Command a owl:Class ;
+    rdfs:label "Off Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Off _:has_Command ) ],
+        brick:On_Off_Command ;
+    skos:definition "An Off Command controls or reports the binary 'off' status of a control loop, relay or equipment activity. It can only be used to stop/deactivate an associated equipment or process, or determine that the related entity is 'off'"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Off,
+        tag:Point .
+
+brick:Office_Kitchen a owl:Class ;
+    rdfs:label "Office Kitchen" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Office [ a owl:Restriction ;
+                        owl:hasValue tag:Kitchen ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A common space, usually near or in a breakroom, where minor food preperation occurs"@en ;
+    brick:hasAssociatedTag tag:Kitchen,
+        tag:Location,
+        tag:Office,
+        tag:Room,
+        tag:Space .
+
+brick:On_Command a owl:Class ;
+    rdfs:label "On Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Command ) ],
+        brick:On_Off_Command ;
+    skos:definition "An On Command controls or reports the binary 'on' status of a control loop, relay or equipment activity. It can only be used to start/activate an associated equipment or process, or determine that the related entity is 'on'"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:On,
+        tag:Point .
+
+brick:On_Timer_Sensor a owl:Class ;
+    rdfs:label "On Timer Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On [ a owl:Restriction ;
+                        owl:hasValue tag:Timer ;
+                        owl:onProperty brick:hasTag ] _:has_Sensor ) ],
+        brick:Duration_Sensor ;
+    owl:equivalentClass brick:Run_Time_Sensor ;
+    skos:definition "Measures the duration for which a device was in an active or \"on\" state"@en ;
+    brick:hasAssociatedTag tag:On,
+        tag:Point,
+        tag:Sensor,
+        tag:Timer .
+
+brick:Open_Heating_Valve_Outside_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Open Heating Valve Outside Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Open _:has_Heat _:has_Valve _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Heating_Temperature_Setpoint,
+        brick:Outside_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Open,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Valve .
+
+brick:Open_Office a owl:Class ;
+    rdfs:label "Open Office" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Open _:has_Office _:has_Room _:has_Space _:has_Location ) ],
+        brick:Office ;
+    skos:definition "An open space used for work or study by mulitple people. Usuaully subdivided into cubicles or desks"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Office,
+        tag:Open,
+        tag:Room,
+        tag:Space .
+
+brick:Operative_Temperature a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Operative Temperature",
+        "Operative_Temperature" ;
+    qudt:applicableUnit unit:DEG_C,
+        unit:DEG_F,
+        unit:K ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:ThermodynamicTemperature,
+        brick:Temperature ;
+    skos:definition "The uniform temperature of an imaginary black enclosure in which an occupant would exchange the same amount of heat by radiation plus convection as in the actual nonuniform environment (https://en.wikipedia.org/wiki/Operative_temperature)",
+        "The uniform temperature of an imaginary black enclosure in which an occupant would exchange the same amount of heat by radiation plus convection as in the actual nonuniform environment (https://en.wikipedia.org/wiki/Operative_temperature)"@en .
+
+brick:Output_Frequency_Sensor a owl:Class ;
+    rdfs:label "Output Frequency Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Output _:has_Frequency _:has_Sensor ) ],
+        brick:Frequency_Sensor ;
+    brick:hasAssociatedTag tag:Frequency,
+        tag:Output,
+        tag:Point,
+        tag:Sensor .
+
+brick:Output_Voltage_Sensor a owl:Class ;
+    rdfs:label "Output Voltage Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Output _:has_Voltage _:has_Sensor ) ],
+        brick:Voltage_Sensor ;
+    skos:definition "Measures the voltage output by some process or device"@en ;
+    brick:hasAssociatedTag tag:Output,
+        tag:Point,
+        tag:Sensor,
+        tag:Voltage .
+
+brick:Outside a owl:Class ;
+    rdfs:label "Outside" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Location ) ],
+        brick:Location ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Outside .
+
+brick:Outside_Air_CO2_Sensor a owl:Class ;
+    rdfs:label "Outside Air CO2 Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_CO2 _:has_Sensor ) ],
+        brick:CO2_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Outside_Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:CO2 ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the concentration of CO2 in outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:CO2,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor .
+
+brick:Outside_Air_CO_Sensor a owl:Class ;
+    rdfs:label "Outside Air CO Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_CO _:has_Sensor ) ],
+        brick:CO_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Outside_Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:CO ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Air,
+        tag:CO,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor .
+
+brick:Outside_Air_Dewpoint_Sensor a owl:Class ;
+    rdfs:label "Outside Air Dewpoint Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint _:has_Air _:has_Outside ) ],
+        brick:Dewpoint_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Dewpoint ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Outside_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Senses the dewpoint temperature of outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Dewpoint,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor .
+
+brick:Outside_Air_Enthalpy_Sensor a owl:Class ;
+    rdfs:label "Outside Air Enthalpy Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Enthalpy _:has_Sensor ) ],
+        brick:Air_Enthalpy_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Enthalpy ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Outside_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the total heat content of outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Enthalpy,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor .
+
+brick:Outside_Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Outside Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Outside ) ],
+        brick:Air_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Outside_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of outside air into the system"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor .
+
+brick:Outside_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Outside Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Air_Flow_Setpoint ;
+    skos:definition "Sets outside air flow rate"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Outside_Air_Grains_Sensor a owl:Class ;
+    rdfs:label "Outside Air Grains Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Grains _:has_Sensor ) ],
+        brick:Air_Grains_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Outside_Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Grains ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the mass of water vapor in outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Grains,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor .
+
+brick:Outside_Air_Humidity_Sensor a owl:Class ;
+    rdfs:label "Outside Air Humidity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Relative _:has_Air _:has_Outside ) ],
+        brick:Relative_Humidity_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Relative_Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Outside_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the relative humidity of outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Outside,
+        tag:Point,
+        tag:Relative,
+        tag:Sensor .
+
+brick:Outside_Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Outside Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air _:has_Outside ) ],
+        brick:Air_Humidity_Setpoint ;
+    skos:definition "Humidity setpoint for outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Outside_Air_Lockout_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Outside Air Lockout Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Setpoint ) ],
+        brick:Outside_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Lockout,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Outside_Air_Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Outside Air Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:High,
+        tag:Outside,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Outside_Air_Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Outside Air Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Low,
+        tag:Outside,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Outside_Air_Wet_Bulb_Temperature_Sensor a owl:Class ;
+    rdfs:label "Outside Air Wet Bulb Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Outside _:has_Air _:has_Wet _:has_Bulb _:has_Temperature _:has_Sensor _:has_Point ) ],
+        brick:Air_Wet_Bulb_Temperature_Sensor,
+        brick:Outside_Air_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wet_Bulb_Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Outside_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "A sensor measuring the wet-bulb temperature of outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Bulb,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Wet .
+
+brick:Outside_Damper a owl:Class ;
+    rdfs:label "Outside Damper" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper _:has_Outside ) ],
+        brick:Damper ;
+    skos:definition "A damper that modulates the flow of outside air"@en ;
+    brick:hasAssociatedTag tag:Damper,
+        tag:Equipment,
+        tag:Outside .
+
+brick:Outside_Illuminance_Sensor a owl:Class ;
+    rdfs:label "Outside Illuminance Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Illuminance _:has_Outside ) ],
+        brick:Illuminance_Sensor ;
+    skos:definition "Measures the total luminous flux incident on an outside, per unit area"@en ;
+    brick:hasAssociatedTag tag:Illuminance,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor .
+
+brick:Overload_Alarm a owl:Class ;
+    rdfs:label "Overload Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Overload ;
+                        owl:onProperty brick:hasTag ] _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that can indicate when a full-load current is exceeded."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Overload,
+        tag:Point .
+
+brick:Overridden_Off_Status a owl:Class ;
+    rdfs:label "Overridden Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Overridden _:has_Off _:has_Status ) ],
+        brick:Off_Status,
+        brick:Overridden_Status ;
+    skos:definition "Indicates if a control loop, relay or equipment has been turned off when it would otherwise be scheduled to be on"@en ;
+    brick:hasAssociatedTag tag:Off,
+        tag:Overridden,
+        tag:Point,
+        tag:Status .
+
+brick:Overridden_On_Status a owl:Class ;
+    rdfs:label "Overridden On Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Overridden _:has_On _:has_Status ) ],
+        brick:On_Status,
+        brick:Overridden_Status ;
+    skos:definition "Indicates if a control loop, relay or equipment has been turned on when it would otherwise be scheduled to be off"@en ;
+    brick:hasAssociatedTag tag:On,
+        tag:Overridden,
+        tag:Point,
+        tag:Status .
+
+brick:PAU a owl:Class ;
+    rdfs:label "PAU" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:PAU ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:AHU ;
+    skos:definition "A type of AHU, use to pre-treat the outdoor air before feed to AHU"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:PAU .
+
+brick:PIR_Sensor a owl:Class ;
+    rdfs:label "PIR Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
+                        owl:hasValue tag:PIR ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Motion_Sensor,
+        brick:Occupancy_Sensor ;
+    skos:definition "Detects the presense of motion in some area using the differential change in infrared intensity between two or more receptors"@en ;
+    brick:hasAssociatedTag tag:PIR,
+        tag:Point,
+        tag:Sensor .
+
+brick:PM10_Level_Sensor a owl:Class ;
+    rdfs:label "PM10 Level Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Level _:has_Sensor _:has_Particulate _:has_Matter _:has_PM10 ) ],
+        brick:PM10_Sensor ;
+    skos:definition "Detects level of particulates of size 10 microns"@en ;
+    brick:hasAssociatedTag tag:Level,
+        tag:Matter,
+        tag:PM10,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor .
+
+brick:PM1_Level_Sensor a owl:Class ;
+    rdfs:label "PM1 Level Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Level _:has_Sensor _:has_Particulate _:has_Matter _:has_PM1 ) ],
+        brick:PM1_Sensor ;
+    skos:definition "Detects level of particulates of size 1 microns"@en ;
+    brick:hasAssociatedTag tag:Level,
+        tag:Matter,
+        tag:PM1,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor .
+
+brick:PM2.5_Level_Sensor a owl:Class ;
+    rdfs:label "PM2.5 Level Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Level _:has_Sensor _:has_Particulate _:has_Matter _:has_PM2.5 ) ],
+        brick:PM2.5_Sensor ;
+    skos:definition "Detects level of particulates of size 2.5 microns"@en ;
+    brick:hasAssociatedTag tag:Level,
+        tag:Matter,
+        tag:PM2.5,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor .
+
+brick:Parking_Level a owl:Class ;
+    rdfs:label "Parking Level" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parking _:has_Level _:has_Location _:has_Floor ) ],
+        brick:Floor ;
+    skos:definition "A floor of a parking structure"@en ;
+    brick:hasAssociatedTag tag:Floor,
+        tag:Level,
+        tag:Location,
+        tag:Parking .
+
+brick:Parking_Space a owl:Class ;
+    rdfs:label "Parking Space" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Parking _:has_Space _:has_Location ) ],
+        brick:Space ;
+    skos:definition "An area large enough to park an individual vehicle"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Parking,
+        tag:Space .
+
+brick:Parking_Structure a owl:Class ;
+    rdfs:label "Parking Structure" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Location _:has_Parking [ a owl:Restriction ;
+                        owl:hasValue tag:Structure ;
+                        owl:onProperty brick:hasTag ] _:has_Building ) ],
+        brick:Building ;
+    skos:definition "A building or part of a building devoted to vehicle parking"@en ;
+    brick:hasAssociatedTag tag:Building,
+        tag:Location,
+        tag:Parking,
+        tag:Structure .
+
+brick:Peak_Power_Demand_Sensor a owl:Class ;
+    rdfs:label "Peak Power Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Peak ;
+                        owl:onProperty brick:hasTag ] _:has_Power _:has_Demand _:has_Sensor _:has_Electrical ) ],
+        brick:Demand_Sensor,
+        brick:Electrical_Power_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Peak_Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "The peak power consumed by a process over some period of time"@en ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Electrical,
+        tag:Peak,
+        tag:Point,
+        tag:Power,
+        tag:Sensor .
+
+brick:Phasor_Magnitude a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Phasor Magnitude",
+        "PhasorMagnitude" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:definition "Magnitude component of a phasor" ;
+    skos:related brick:Phasor .
+
+brick:Photovoltaic_Current_Output_Sensor a owl:Class ;
+    rdfs:label "Photovoltaic Current Output Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Photovoltaic ;
+                        owl:onProperty brick:hasTag ] _:has_Current _:has_Output _:has_Sensor ) ],
+        brick:Current_Output_Sensor ;
+    owl:equivalentClass brick:PV_Current_Output_Sensor ;
+    skos:definition "Senses the amperes of electrical current produced as output by a photovoltaic device"@en ;
+    brick:hasAssociatedTag tag:Current,
+        tag:Output,
+        tag:Photovoltaic,
+        tag:Point,
+        tag:Sensor .
+
+brick:Piezoelectric_Sensor a owl:Class ;
+    rdfs:label "Piezoelectric Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
+                        owl:hasValue tag:Piezoelectric ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Sensor ;
+    skos:definition "Senses changes pressure, acceleration, temperature, force or strain via the piezoelectric effect"@en ;
+    brick:hasAssociatedTag tag:Piezoelectric,
+        tag:Point,
+        tag:Sensor .
+
+brick:PlugStrip a owl:Class ;
+    rdfs:label "PlugStrip" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Power_strip> ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:PlugStrip ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Electrical_Equipment ;
+    skos:definition "A device containing a block of electrical sockets allowing multiple electrical devices to be powered from a single electrical socket."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:PlugStrip .
+
+brick:Plumbing_Room a owl:Class ;
+    rdfs:label "Plumbing Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Plumbing ;
+                        owl:onProperty brick:hasTag ] _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Service_Room ;
+    skos:definition "A service room devoted to the operation and routing of water in a building. Usually distinct from the HVAC subsystems."@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Plumbing,
+        tag:Room,
+        tag:Service,
+        tag:Space .
+
+brick:Power_Factor a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Power Factor" ;
+    qudt:applicableUnit unit:UNITLESS ;
+    owl:sameAs qudtqk:PowerFactor ;
+    skos:definition "Power Factor, under periodic conditions, is the ratio of the absolute value of the active power (P) to the apparent power (S)."@en .
+
+brick:Power_Loss_Alarm a owl:Class ;
+    rdfs:label "Power Loss Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Power _:has_Loss _:has_Alarm ) ],
+        brick:Power_Alarm ;
+    skos:definition "An alarm that indicates a power failure."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Loss,
+        tag:Point,
+        tag:Power .
+
+brick:Prayer_Room a owl:Class ;
+    rdfs:label "Prayer Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Prayer ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A room set aside for prayer"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Prayer,
+        tag:Room,
+        tag:Space .
+
+brick:Pre_Filter a owl:Class ;
+    rdfs:label "Pre Filter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pre _:has_Filter ) ],
+        brick:Filter ;
+    skos:definition "A filter installed in front of a more efficient filter to extend the life of the more expensive higher efficiency filter"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Filter,
+        tag:Pre .
+
+brick:Pre_Filter_Status a owl:Class ;
+    rdfs:label "Pre Filter Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pre _:has_Filter _:has_Status ) ],
+        brick:Filter_Status ;
+    skos:definition "Indicates if a prefilter needs to be replaced"@en ;
+    brick:hasAssociatedTag tag:Filter,
+        tag:Point,
+        tag:Pre,
+        tag:Status .
+
+brick:Preheat_Demand_Setpoint a owl:Class ;
+    rdfs:label "Preheat Demand Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Preheat _:has_Demand _:has_Setpoint ) ],
+        brick:Demand_Setpoint ;
+    skos:definition "Sets the rate required for preheat"@en ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Point,
+        tag:Preheat,
+        tag:Setpoint .
+
+brick:Preheat_Hot_Water_System a owl:Class ;
+    rdfs:label "Preheat Hot Water System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_System _:has_Preheat _:has_System ) ],
+        brick:Hot_Water_System ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Preheat,
+        tag:System,
+        tag:Water .
+
+brick:Preheat_Hot_Water_Valve a owl:Class ;
+    rdfs:label "Preheat Hot Water Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Preheat _:has_Water _:has_Hot _:has_Valve _:has_Heat _:has_Equipment ) ],
+        brick:Hot_Water_Valve ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heat,
+        tag:Hot,
+        tag:Preheat,
+        tag:Valve,
+        tag:Water .
+
+brick:Preheat_Supply_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Preheat Supply Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Preheat _:has_Supply _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Supply_Air_Temperature_Sensor ;
+    owl:equivalentClass brick:Preheat_Discharge_Air_Temperature_Sensor ;
+    skos:definition "Measures the temperature of supply air before it is heated"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Preheat,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Private_Office a owl:Class ;
+    rdfs:label "Private Office" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Private ;
+                        owl:onProperty brick:hasTag ] _:has_Enclosed _:has_Office _:has_Room _:has_Space _:has_Location ) ],
+        brick:Enclosed_Office ;
+    skos:definition "An office devoted to a single individual, with walls and door"@en ;
+    brick:hasAssociatedTag tag:Enclosed,
+        tag:Location,
+        tag:Office,
+        tag:Private,
+        tag:Room,
+        tag:Space .
+
+brick:Pump_Command a owl:Class ;
+    rdfs:label "Pump Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pump _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls or reports the speed of a pump (typically as a proportion of its full pumping capacity)"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Pump .
+
+brick:Pump_On_Off_Status a owl:Class ;
+    rdfs:label "Pump On Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pump _:has_On _:has_Off _:has_Status ) ],
+        brick:On_Off_Status ;
+    brick:hasAssociatedTag tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Pump,
+        tag:Status .
+
+brick:Pump_Room a owl:Class ;
+    rdfs:label "Pump Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Pump _:has_Mechanical _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Mechanical_Room ;
+    skos:definition "A mechanical room that houses pumps"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Mechanical,
+        tag:Pump,
+        tag:Room,
+        tag:Service,
+        tag:Space .
+
+brick:Pump_VFD a owl:Class ;
+    rdfs:label "Pump VFD" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_VFD ) ],
+        brick:VFD ;
+    skos:definition "Variable-frequency drive for pumps"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Pump,
+        tag:VFD .
+
+brick:Radiant_Temperature a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Radiant Temperature",
+        "Radiant_Temperature" ;
+    qudt:applicableUnit unit:DEG_C,
+        unit:DEG_F,
+        unit:K ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:ThermodynamicTemperature,
+        brick:Temperature ;
+    skos:definition "the uniform temperature of an imaginary enclosure in which the radiant heat transfer from the human body is equal to the radiant heat transfer in the actual non-uniform enclosure. (https://en.wikipedia.org/wiki/Mean_radiant_temperature)",
+        "the uniform temperature of an imaginary enclosure in which the radiant heat transfer from the human body is equal to the radiant heat transfer in the actual non-uniform enclosure. (https://en.wikipedia.org/wiki/Mean_radiant_temperature)"@en .
+
+brick:Radiation_Hot_Water_System a owl:Class ;
+    rdfs:label "Radiation Hot Water System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_System [ a owl:Restriction ;
+                        owl:hasValue tag:Radiation ;
+                        owl:onProperty brick:hasTag ] _:has_System ) ],
+        brick:Hot_Water_System ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Radiation,
+        tag:System,
+        tag:Water .
+
+brick:Rain_Duration_Sensor a owl:Class ;
+    rdfs:label "Rain Duration Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Rain _:has_Duration ) ],
+        brick:Duration_Sensor,
+        brick:Rain_Sensor ;
+    skos:definition "Measures the duration of precipitation within some time frame"@en ;
+    brick:hasAssociatedTag tag:Duration,
+        tag:Point,
+        tag:Rain,
+        tag:Sensor .
+
+brick:Rated_Speed_Setpoint a owl:Class ;
+    rdfs:label "Rated Speed Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Rated ;
+                        owl:onProperty brick:hasTag ] _:has_Speed _:has_Setpoint ) ],
+        brick:Speed_Setpoint ;
+    skos:definition "Sets rated speed"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Rated,
+        tag:Setpoint,
+        tag:Speed .
+
+brick:Reactive_Power_Sensor a owl:Class ;
+    rdfs:label "Reactive Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power [ a owl:Restriction ;
+                        owl:hasValue tag:Reactive ;
+                        owl:onProperty brick:hasTag ] _:has_Electrical ) ],
+        brick:Electrical_Power_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Reactive_Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the portion of power that, averaged over a complete cycle of the AC waveform, is due to stored energy which returns to the source in each cycle"@en ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Point,
+        tag:Power,
+        tag:Reactive,
+        tag:Sensor .
+
+brick:Reception a owl:Class ;
+    rdfs:label "Reception" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Reception ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A space, usually in a lobby, where visitors to a building or space can go to after arriving at a building and inform building staff that they have arrived"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Reception,
+        tag:Room,
+        tag:Space .
+
+brick:Region a owl:Class ;
+    rdfs:label "Region" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Location [ a owl:Restriction ;
+                        owl:hasValue tag:Region ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Location ;
+    skos:definition "A unit of geographic space, usually contigious or somehow related to a geopolitical feature"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Region .
+
+brick:Reheat_Hot_Water_System a owl:Class ;
+    rdfs:label "Reheat Hot Water System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Water _:has_System _:has_Reheat _:has_System ) ],
+        brick:Hot_Water_System ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Reheat,
+        tag:System,
+        tag:Water .
+
+brick:Reheat_Valve a owl:Class ;
+    rdfs:label "Reheat Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Reheat _:has_Heat _:has_Equipment ) ],
+        brick:Heating_Valve ;
+    skos:definition "A valve that controls air temperature by modulating the amount of hot water flowing through a reheat coil"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heat,
+        tag:Reheat,
+        tag:Valve .
+
+brick:Remotely_On_Off_Status a owl:Class ;
+    rdfs:label "Remotely On Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Remotely ;
+                        owl:onProperty brick:hasTag ] _:has_On _:has_Off _:has_Status ) ],
+        brick:On_Off_Status ;
+    brick:hasAssociatedTag tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Remotely,
+        tag:Status .
+
+brick:Retail_Room a owl:Class ;
+    rdfs:label "Retail Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Retail ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A space set aside for retail in a larger establishment, e.g. a gift shop in a hospital"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Retail,
+        tag:Room,
+        tag:Space .
+
+brick:Return_Air_CO2_Sensor a owl:Class ;
+    rdfs:label "Return Air CO2 Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_CO2 _:has_Sensor ) ],
+        brick:CO2_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:CO2 ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the concentration of CO2 in return air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:CO2,
+        tag:Point,
+        tag:Return,
+        tag:Sensor .
+
+brick:Return_Air_CO2_Setpoint a owl:Class ;
+    rdfs:label "Return Air CO2 Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_CO2 _:has_Setpoint ) ],
+        brick:CO2_Setpoint ;
+    skos:definition "Sets some property of CO2 in Return Air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:CO2,
+        tag:Point,
+        tag:Return,
+        tag:Setpoint .
+
+brick:Return_Air_CO_Sensor a owl:Class ;
+    rdfs:label "Return Air CO Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_CO _:has_Sensor ) ],
+        brick:CO_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:CO ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Air,
+        tag:CO,
+        tag:Point,
+        tag:Return,
+        tag:Sensor .
+
+brick:Return_Air_Dewpoint_Sensor a owl:Class ;
+    rdfs:label "Return Air Dewpoint Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint _:has_Air _:has_Return ) ],
+        brick:Dewpoint_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Dewpoint ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Senses the dewpoint temperature of return air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Dewpoint,
+        tag:Point,
+        tag:Return,
+        tag:Sensor .
+
+brick:Return_Air_Differential_Pressure_Sensor a owl:Class ;
+    rdfs:label "Return Air Differential Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Sensor _:has_Pressure _:has_Differential ) ],
+        brick:Air_Differential_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the difference in pressure between the return and supply side"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Return,
+        tag:Sensor .
+
+brick:Return_Air_Enthalpy_Sensor a owl:Class ;
+    rdfs:label "Return Air Enthalpy Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Enthalpy _:has_Sensor ) ],
+        brick:Air_Enthalpy_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Enthalpy ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the total heat content of return air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Enthalpy,
+        tag:Point,
+        tag:Return,
+        tag:Sensor .
+
+brick:Return_Air_Filter a owl:Class ;
+    rdfs:label "Return Air Filter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Return _:has_Air _:has_Filter ) ],
+        brick:Filter ;
+    skos:definition "Filters return air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Filter,
+        tag:Return .
+
+brick:Return_Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Return Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Return ) ],
+        brick:Air_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of return air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Point,
+        tag:Return,
+        tag:Sensor .
+
+brick:Return_Air_Grains_Sensor a owl:Class ;
+    rdfs:label "Return Air Grains Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Grains _:has_Sensor ) ],
+        brick:Air_Grains_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Grains ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the mass of water vapor in return air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Grains,
+        tag:Point,
+        tag:Return,
+        tag:Sensor .
+
+brick:Return_Air_Humidity_Sensor a owl:Class ;
+    rdfs:label "Return Air Humidity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Relative _:has_Air _:has_Return ) ],
+        brick:Relative_Humidity_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Relative_Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the relative humidity of return air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Point,
+        tag:Relative,
+        tag:Return,
+        tag:Sensor .
+
+brick:Return_Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Return Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air _:has_Return ) ],
+        brick:Air_Humidity_Setpoint ;
+    skos:definition "Humidity setpoint for return air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Point,
+        tag:Return,
+        tag:Setpoint .
+
+brick:Return_Air_Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Return Air Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:High,
+        tag:Point,
+        tag:Reset,
+        tag:Return,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Return_Air_Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Return Air Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Return,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Return_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Return Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Return ) ],
+        brick:Air_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of return air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Return_Condenser_Water_Flow_Sensor a owl:Class ;
+    rdfs:label "Return Condenser Water Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Return _:has_Condenser ) ],
+        brick:Return_Water_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Condenser_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the flow of the return condenser water"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Flow,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Water .
+
+brick:Return_Condenser_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Return Condenser Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Return _:has_Condenser _:has_Water _:has_Temperature _:has_Sensor _:has_Point ) ],
+        brick:Condenser_Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Condenser_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of the return condenser water"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Return_Damper a owl:Class ;
+    rdfs:label "Return Damper" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper _:has_Return ) ],
+        brick:Damper ;
+    skos:definition "A damper that modulates the flow of return air"@en ;
+    brick:hasAssociatedTag tag:Damper,
+        tag:Equipment,
+        tag:Return .
+
+brick:Return_Fan a owl:Class ;
+    rdfs:label "Return Fan" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_Return ) ],
+        brick:Fan ;
+    skos:definition "Fan moving return air -- air that is circulated from the building back into the HVAC system"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fan,
+        tag:Return .
+
+brick:Return_Heating_Valve a owl:Class ;
+    rdfs:label "Return Heating Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Return _:has_Heat _:has_Equipment ) ],
+        brick:Heating_Valve ;
+    skos:definition "A valve installed on the return side of a heat exchanger"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heat,
+        tag:Return,
+        tag:Valve .
+
+brick:Return_Hot_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Return Hot Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Temperature _:has_Setpoint _:has_Return ) ],
+        brick:Water_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Point,
+        tag:Return,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+brick:Riser a owl:Class ;
+    rdfs:label "Riser" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Riser _:has_Vertical _:has_Space _:has_Location ) ],
+        brick:Vertical_Space ;
+    skos:definition "A low platform in a space or on a stage"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Riser,
+        tag:Space,
+        tag:Vertical .
+
+brick:Rooftop a owl:Class ;
+    rdfs:label "Rooftop" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Rooftop _:has_Location _:has_Floor ) ],
+        brick:Floor ;
+    brick:hasAssociatedTag tag:Floor,
+        tag:Location,
+        tag:Rooftop .
+
+brick:Run_Enable_Command a owl:Class ;
+    rdfs:label "Run Enable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Run ) ],
+        brick:Enable_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Enable,
+        tag:Point,
+        tag:Run .
+
+brick:Run_Request_Status a owl:Class ;
+    rdfs:label "Run Request Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Request ;
+                        owl:onProperty brick:hasTag ] _:has_Run _:has_Status ) ],
+        brick:Run_Status ;
+    skos:definition "Indicates if a request has been filed to start a device or equipment"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Request,
+        tag:Run,
+        tag:Status .
+
+brick:Safety_Shower a owl:Class ;
+    rdfs:label "Safety Shower" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Safety _:has_Wash _:has_Station _:has_Emergency _:has_Shower ) ],
+        brick:Emergency_Wash_Station ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Equipment,
+        tag:Safety,
+        tag:Shower,
+        tag:Station,
+        tag:Wash .
+
+brick:Sash_Position_Sensor a owl:Class ;
+    rdfs:label "Sash Position Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Sash ;
+                        owl:onProperty brick:hasTag ] _:has_Position _:has_Sensor ) ],
+        brick:Position_Sensor ;
+    skos:definition "Measures the current position of a sash in terms of the percent of fully open"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Position,
+        tag:Sash,
+        tag:Sensor .
+
+brick:Schedule_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Schedule Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint [ a owl:Restriction ;
+                        owl:hasValue tag:Schedule ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Temperature_Setpoint ;
+    skos:definition "The current setpoint as indicated by the schedule"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Schedule,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Server_Room a owl:Class ;
+    rdfs:label "Server Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Server ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Location ) ],
+        brick:Room ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Server .
+
+brick:Shading_System a owl:Class ;
+    rdfs:label "Shading System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Shade _:has_System ) ],
+        brick:System ;
+    skos:definition "Devices that can control daylighting through various means"@en ;
+    brick:hasAssociatedTag tag:Shade,
+        tag:System .
+
+brick:Shared_Office a owl:Class ;
+    rdfs:label "Shared Office" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Shared ;
+                        owl:onProperty brick:hasTag ] _:has_Enclosed _:has_Office _:has_Room _:has_Space _:has_Location ) ],
+        brick:Enclosed_Office ;
+    skos:definition "An office used by multiple people"@en ;
+    brick:hasAssociatedTag tag:Enclosed,
+        tag:Location,
+        tag:Office,
+        tag:Room,
+        tag:Shared,
+        tag:Space .
+
+brick:Short_Cycle_Alarm a owl:Class ;
+    rdfs:label "Short Cycle Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Short ;
+                        owl:onProperty brick:hasTag ] _:has_Cycle _:has_Alarm ) ],
+        brick:Cycle_Alarm ;
+    skos:definition "An alarm that indicates a short cycle occurred. A short cycle occurs when a cooling cycle is prevented from completing its full cycle"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Cycle,
+        tag:Point,
+        tag:Short .
+
+brick:Shower a owl:Class ;
+    rdfs:label "Shower" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Shower _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A space containing showers, usually adjacent to an athletic or execise area"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Shower,
+        tag:Space .
+
+brick:Site a owl:Class ;
+    rdfs:label "Site" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Site ;
+                        owl:onProperty brick:hasTag ] _:has_Location ) ],
+        brick:Location ;
+    skos:definition "A geographic region containing 0 or more buildings. Typically used as the encapsulating location for a collection of Brick entities through the hasSite/isSiteOf relationships"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Site .
+
+brick:Solar_Azimuth_Angle_Sensor a owl:Class ;
+    rdfs:label "Solar Azimuth Angle Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Solar [ a owl:Restriction ;
+                        owl:hasValue tag:Azimuth ;
+                        owl:onProperty brick:hasTag ] _:has_Angle _:has_Sensor ) ],
+        brick:Angle_Sensor ;
+    skos:definition "Measures the azimuth angle of the sun"@en ;
+    brick:hasAssociatedTag tag:Angle,
+        tag:Azimuth,
+        tag:Point,
+        tag:Sensor,
+        tag:Solar .
+
+brick:Solar_Irradiance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Solar Irradiance",
+        "SolarIrradiance" ;
+    qudt:applicableUnit unit:W-PER-CeniM2,
+        unit:W-PER-FT2,
+        unit:W-PER-IN2,
+        unit:W-PER-M2 ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Irradiance ;
+    skos:definition "The power per unit area of solar electromagnetic radiation incident on a surface",
+        "The power per unit area of solar electromagnetic radiation incident on a surface"@en .
+
+brick:Solar_Panel a owl:Class ;
+    rdfs:label "Solar Panel" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Solar_panel> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solar _:has_Equipment ) ],
+        brick:Equipment ;
+    skos:definition "A colloquial term for a photovoltaic module. A Solar panel is an assembly of photovoltaic cells mounted in a framework for installation that use sunlight as a source of energy to generate direct current electricity."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Solar .
+
+brick:Solar_Radiance_Sensor a owl:Class ;
+    rdfs:label "Solar Radiance Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
+                        owl:hasValue tag:Radiance ;
+                        owl:onProperty brick:hasTag ] _:has_Solar ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Solar_Radiance ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Radiance,
+        tag:Sensor,
+        tag:Solar .
+
+brick:Solar_Zenith_Angle_Sensor a owl:Class ;
+    rdfs:label "Solar Zenith Angle Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Solar [ a owl:Restriction ;
+                        owl:hasValue tag:Zenith ;
+                        owl:onProperty brick:hasTag ] _:has_Angle _:has_Sensor ) ],
+        brick:Angle_Sensor ;
+    skos:definition "Measures the zenith angle of the sun"@en ;
+    brick:hasAssociatedTag tag:Angle,
+        tag:Point,
+        tag:Sensor,
+        tag:Solar,
+        tag:Zenith .
+
+brick:Space_Heater a owl:Class ;
+    rdfs:label "Space Heater" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Space _:has_Heater ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "A heater used to warm the air in an enclosed area, such as a room or office"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heater,
+        tag:Space .
+
+brick:Speed_Reset_Command a owl:Class ;
+    rdfs:label "Speed Reset Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Reset _:has_Command ) ],
+        brick:Reset_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Reset,
+        tag:Speed .
+
+brick:Speed_Status a owl:Class ;
+    rdfs:label "Speed Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates the operating speed of a device or equipment, e.g. fan"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Speed,
+        tag:Status .
+
+brick:Sports_Service_Room a owl:Class ;
+    rdfs:label "Sports Service Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Sports ;
+                        owl:onProperty brick:hasTag ] _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A class of spaces used in the support of sports"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Service,
+        tag:Space,
+        tag:Sports .
+
+brick:Stage_Enable_Command a owl:Class ;
+    rdfs:label "Stage Enable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Stage ;
+                        owl:onProperty brick:hasTag ] _:has_Enable _:has_Command _:has_Point ) ],
+        brick:Enable_Command ;
+    skos:definition "A point representing a discrete stage which the equipment should be operating at. The desired stage number should be identified by an entity property"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Enable,
+        tag:Point,
+        tag:Stage .
+
+brick:Stages_Status a owl:Class ;
+    rdfs:label "Stages Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Stages ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates which stage a control loop or equipment is in"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Stages,
+        tag:Status .
+
+brick:Staircase a owl:Class ;
+    rdfs:label "Staircase" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Staircase ;
+                        owl:onProperty brick:hasTag ] _:has_Vertical _:has_Space _:has_Location ) ],
+        brick:Vertical_Space ;
+    skos:definition "A vertical space containing stairs"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Space,
+        tag:Staircase,
+        tag:Vertical .
+
+brick:Standby_CRAC a owl:Class ;
+    rdfs:label "Standby CRAC" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_CRAC _:has_Standby ) ],
+        brick:CRAC ;
+    skos:definition "A CRAC that is activated as part of a lead/lag operation or when an alarm occurs in a primary unit"@en ;
+    brick:hasAssociatedTag tag:CRAC,
+        tag:Equipment,
+        tag:Standby .
+
+brick:Standby_Fan a owl:Class ;
+    rdfs:label "Standby Fan" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_Standby ) ],
+        brick:Fan ;
+    skos:definition "Fan that is activated as part of a lead/lag operation or when a primary fan raises an alarm"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fan,
+        tag:Standby .
+
+brick:Standby_Glycool_Unit_On_Off_Status a owl:Class ;
+    rdfs:label "Standby Glycool Unit On Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Standby [ a owl:Restriction ;
+                        owl:hasValue tag:Glycool ;
+                        owl:onProperty brick:hasTag ] _:has_Unit _:has_On _:has_Off _:has_Status ) ],
+        brick:Standby_Unit_On_Off_Status ;
+    skos:definition "Indicates the on/off status of a standby glycool unit"@en ;
+    brick:hasAssociatedTag tag:Glycool,
+        tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Standby,
+        tag:Status,
+        tag:Unit .
+
+brick:Start_Stop_Command a owl:Class ;
+    rdfs:label "Start Stop Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Start _:has_Stop _:has_Command ) ],
+        brick:On_Off_Command ;
+    skos:definition "A Start/Stop Command controls or reports the active/inactive status of a control sequence"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Start,
+        tag:Stop .
+
+brick:Steam_Baseboard_Radiator a owl:Class ;
+    rdfs:label "Steam Baseboard Radiator" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Radiator _:has_Baseboard _:has_Steam ) ],
+        brick:Baseboard_Radiator,
+        brick:Steam_Radiator ;
+    skos:definition "Steam heating device located at or near the floor"@en ;
+    brick:hasAssociatedTag tag:Baseboard,
+        tag:Equipment,
+        tag:Radiator,
+        tag:Steam .
+
+brick:Steam_Distribution a owl:Class ;
+    rdfs:label "Steam Distribution" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Steam _:has_Distribution _:has_Equipment ) ],
+        brick:Equipment ;
+    skos:definition "Utilize a steam distribution source to represent how steam is distributed across multiple destinations"@en ;
+    brick:hasAssociatedTag tag:Distribution,
+        tag:Equipment,
+        tag:Steam .
+
+brick:Steam_On_Off_Command a owl:Class ;
+    rdfs:label "Steam On Off Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Steam _:has_On _:has_Off _:has_Command ) ],
+        brick:On_Off_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Steam .
+
+brick:Steam_System a owl:Class ;
+    rdfs:label "Steam System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Steam _:has_System ) ],
+        brick:Heating_Ventilation_Air_Conditioning_System ;
+    skos:definition "The equipment, devices and conduits that handle the production and distribution of steam in a building"@en ;
+    brick:hasAssociatedTag tag:Steam,
+        tag:System .
+
+brick:Steam_Usage_Sensor a owl:Class ;
+    rdfs:label "Steam Usage Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage _:has_Steam ) ],
+        brick:Usage_Sensor ;
+    skos:definition "Measures the amount of steam that is consumed or used, over some period of time"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
+        tag:Steam,
+        tag:Usage .
+
+brick:Steam_Valve a owl:Class ;
+    rdfs:label "Steam Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Steam _:has_Valve _:has_Equipment ) ],
+        brick:Valve ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Steam,
+        tag:Valve .
+
+brick:Studio a owl:Class ;
+    rdfs:label "Studio" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Studio ;
+                        owl:onProperty brick:hasTag ] _:has_Media _:has_Room _:has_Space _:has_Location ) ],
+        brick:Media_Room ;
+    skos:definition "A room used for the production or media, usually with either a specialized set or a specialized sound booth for recording"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Media,
+        tag:Room,
+        tag:Space,
+        tag:Studio .
+
+brick:Supply_Air_Duct_Pressure_Status a owl:Class ;
+    rdfs:label "Supply Air Duct Pressure Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
+        brick:Pressure_Status ;
+    owl:equivalentClass brick:Discharge_Air_Duct_Pressure_Status ;
+    skos:definition "Indicates if air pressure in supply duct is within expected bounds"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Duct,
+        tag:Point,
+        tag:Pressure,
+        tag:Status,
+        tag:Supply .
+
+brick:Supply_Air_Flow_Demand_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Flow Demand Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
+        brick:Air_Flow_Demand_Setpoint,
+        brick:Supply_Air_Flow_Setpoint ;
+    owl:equivalentClass brick:Discharge_Air_Flow_Demand_Setpoint ;
+    skos:definition "Sets the rate of supply air flow required for a process"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Demand,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Supply_Air_Humidity_Sensor a owl:Class ;
+    rdfs:label "Supply Air Humidity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Relative _:has_Air _:has_Supply ) ],
+        brick:Relative_Humidity_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Relative_Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Air ;
+                        owl:onProperty brick:measures ] ) ],
+        brick:Discharge_Air_Humidity_Sensor ;
+    skos:definition "Measures the relative humidity of supply air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Point,
+        tag:Relative,
+        tag:Sensor,
+        tag:Supply .
+
+brick:Supply_Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air _:has_Supply ) ],
+        brick:Air_Humidity_Setpoint ;
+    skos:definition "Humidity setpoint for supply air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Supply_Air_Integral_Gain_Parameter a owl:Class ;
+    rdfs:label "Supply Air Integral Gain Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Integral _:has_Gain _:has_Parameter _:has_PID ) ],
+        brick:Integral_Gain_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Gain,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Supply .
+
+brick:Supply_Air_Proportional_Gain_Parameter a owl:Class ;
+    rdfs:label "Supply Air Proportional Gain Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Proportional _:has_Supply _:has_Air ) ],
+        brick:Proportional_Gain_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Gain,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Supply .
+
+brick:Supply_Air_Static_Pressure_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Static Pressure Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+        brick:Static_Pressure_Deadband_Setpoint,
+        brick:Supply_Air_Static_Pressure_Setpoint ;
+    owl:equivalentClass brick:Discharge_Air_Static_Pressure_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of static pressure of supply air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Deadband,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static,
+        tag:Supply .
+
+brick:Supply_Air_Static_Pressure_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Supply Air Static Pressure Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Static_Pressure_Integral_Time_Parameter ;
+    owl:equivalentClass brick:Discharge_Air_Static_Pressure_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Static,
+        tag:Supply,
+        tag:Time .
+
+brick:Supply_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Supply Air Static Pressure Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Static_Pressure_Proportional_Band_Parameter ;
+    owl:equivalentClass brick:Discharge_Air_Static_Pressure_Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Proportional,
+        tag:Static,
+        tag:Supply .
+
+brick:Supply_Air_Static_Pressure_Sensor a owl:Class ;
+    rdfs:label "Supply Air Static Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Supply ) ],
+        brick:Static_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Static_Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Air ;
+                        owl:onProperty brick:measures ] ) ],
+        brick:Discharge_Air_Static_Pressure_Sensor ;
+    skos:definition "The static pressure of air within supply regions of an HVAC system"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Static,
+        tag:Supply .
+
+brick:Supply_Air_Temperature_Alarm a owl:Class ;
+    rdfs:label "Supply Air Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Alarm ) ],
+        brick:Air_Temperature_Alarm ;
+    owl:equivalentClass brick:Discharge_Air_Temperature_Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with the temperature of supply air."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Point,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Supply_Air_Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    owl:equivalentClass brick:Discharge_Air_Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:High,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Supply_Air_Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    owl:equivalentClass brick:Discharge_Air_Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Supply_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Temperature Reset Differential Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Differential_Reset_Setpoint ;
+    owl:equivalentClass brick:Discharge_Air_Temperature_Reset_Differential_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Supply_Air_Temperature_Step_Parameter a owl:Class ;
+    rdfs:label "Supply Air Temperature Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
+        brick:Air_Temperature_Step_Parameter ;
+    owl:equivalentClass brick:Discharge_Air_Temperature_Step_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Parameter,
+        tag:Point,
+        tag:Step,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Supply_Air_Velocity_Pressure_Sensor a owl:Class ;
+    rdfs:label "Supply Air Velocity Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity _:has_Supply _:has_Air ) ],
+        brick:Velocity_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Velocity_Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Air ;
+                        owl:onProperty brick:measures ] ) ],
+        brick:Discharge_Air_Velocity_Pressure_Sensor ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Supply,
+        tag:Velocity .
+
+brick:Supply_Chilled_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Supply Chilled Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint _:has_Chilled ) ],
+        brick:Supply_Water_Temperature_Setpoint ;
+    skos:definition "Temperature setpoint for supply chilled water"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Supply_Condenser_Water_Flow_Sensor a owl:Class ;
+    rdfs:label "Supply Condenser Water Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Supply _:has_Condenser ) ],
+        brick:Supply_Water_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Condenser_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the flow of the supply condenser water"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Water .
+
+brick:Supply_Condenser_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Supply Condenser Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Supply _:has_Condenser _:has_Water _:has_Temperature _:has_Sensor _:has_Point ) ],
+        brick:Condenser_Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Condenser_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of the supply condenser water"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Supply_Condenser_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Supply Condenser Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint _:has_Condenser ) ],
+        brick:Supply_Water_Temperature_Setpoint ;
+    skos:definition "The temperature setpoint for the supply condenser water"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Supply_Fan a owl:Class ;
+    rdfs:label "Supply Fan" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_Supply ) ],
+        brick:Fan ;
+    owl:equivalentClass brick:Discharge_Fan ;
+    skos:definition "Fan moving supply air -- air that is supplied from the HVAC system into the building"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fan,
+        tag:Supply .
+
+brick:Supply_Hot_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Supply Hot Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint _:has_Hot ) ],
+        brick:Supply_Water_Temperature_Setpoint ;
+    skos:definition "Temperature setpoint for supply hot water"@en ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Supply_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Supply Water Differential Pressure Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+        brick:Differential_Pressure_Deadband_Setpoint ;
+    owl:equivalentClass brick:Discharge_Water_Differential_Pressure_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of differential pressure of supply water"@en ;
+    brick:hasAssociatedTag tag:Deadband,
+        tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Water .
+
+brick:Supply_Water_Differential_Pressure_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Supply Water Differential Pressure Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Differential_Pressure_Integral_Time_Parameter,
+        brick:Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Supply,
+        tag:Time,
+        tag:Water .
+
+brick:Supply_Water_Differential_Pressure_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Supply Water Differential Pressure Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Differential_Pressure_Proportional_Band ;
+    brick:hasAssociatedTag tag:Band,
+        tag:Differential,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Proportional,
+        tag:Supply,
+        tag:Water .
+
+brick:Supply_Water_Temperature_Alarm a owl:Class ;
+    rdfs:label "Supply Water Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Alarm ) ],
+        brick:Water_Temperature_Alarm ;
+    owl:equivalentClass brick:Discharge_Water_Temperature_Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with temperature of the supply water."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Supply_Water_Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Supply Water Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Supply_Water_Temperature_Setpoint,
+        brick:Temperature_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature of supply water"@en ;
+    brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Supply_Water_Temperature_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Supply Water Temperature Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Integral_Time_Parameter,
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Supply,
+        tag:Temperature,
+        tag:Time,
+        tag:Water .
+
+brick:Supply_Water_Temperature_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Supply Water Temperature Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Proportional_Band_Parameter,
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Band,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Surveillance_Camera a owl:Class ;
+    rdfs:label "Surveillance Camera" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Security _:has_Video _:has_Surveillance _:has_Camera ) ],
+        brick:Camera,
+        brick:Video_Surveillance_Equipment ;
+    brick:hasAssociatedTag tag:Camera,
+        tag:Equipment,
+        tag:Security,
+        tag:Surveillance,
+        tag:Video .
+
+brick:Switch_Room a owl:Class ;
+    rdfs:label "Switch Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Switch _:has_Telecom _:has_Room _:has_Space _:has_Location ) ],
+        brick:Telecom_Room ;
+    skos:definition "A telecommuncations room housing network switches"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:Switch,
+        tag:Telecom .
+
+brick:Switchgear a owl:Class ;
+    rdfs:label "Switchgear" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Switchgear ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Electrical_Equipment ;
+    skos:definition "A main disconnect or service disconnect feeds power to a switchgear, which then distributes power to the rest of the building through smaller amperage-rated disconnects."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Switchgear .
+
+brick:System_Shutdown_Status a owl:Class ;
+    rdfs:label "System Shutdown Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System [ a owl:Restriction ;
+                        owl:hasValue tag:Shutdown ;
+                        owl:onProperty brick:hasTag ] _:has_Status ) ],
+        brick:Status,
+        brick:System_Status ;
+    skos:definition "Indicates if a system has been shutdown"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Shutdown,
+        tag:Status,
+        tag:System .
+
+brick:TETRA_Room a owl:Class ;
+    rdfs:label "TETRA Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:TETRA ;
+                        owl:onProperty brick:hasTag ] _:has_Telecom _:has_Room _:has_Space _:has_Location ) ],
+        brick:Telecom_Room ;
+    skos:definition "A room used for local two-way radio networks, e.g. the portable radios carried by facilities staff"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:TETRA,
+        tag:Telecom .
+
+brick:TVOC_Level_Sensor a owl:Class ;
+    rdfs:label "TVOC Level Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Level _:has_Sensor _:has_Particulate _:has_Matter _:has_TVOC ) ],
+        brick:TVOC_Sensor ;
+    skos:definition "A sensor measuring the level of all VOCs in air"@en ;
+    brick:hasAssociatedTag tag:Level,
+        tag:Matter,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor,
+        tag:TVOC .
+
+brick:Team_Room a owl:Class ;
+    rdfs:label "Team Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Team ;
+                        owl:onProperty brick:hasTag ] _:has_Enclosed _:has_Office _:has_Room _:has_Space _:has_Location ) ],
+        brick:Enclosed_Office ;
+    skos:definition "An office used by multiple team members for specific work tasks. Distinct from Conference Room"@en ;
+    brick:hasAssociatedTag tag:Enclosed,
+        tag:Location,
+        tag:Office,
+        tag:Room,
+        tag:Space,
+        tag:Team .
+
+brick:Temperature_Tolerance_Parameter a owl:Class ;
+    rdfs:label "Temperature Tolerance Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Tolerance _:has_Parameter _:has_Temperature ) ],
+        brick:Temperature_Parameter,
+        brick:Tolerance_Parameter ;
+    skos:definition "A parameter determining the difference between upper and lower limits of temperature."@en ;
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
+        tag:Temperature,
+        tag:Tolerance .
+
+brick:Temporary_Occupancy_Status a owl:Class ;
+    rdfs:label "Temporary Occupancy Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Temporary ;
+                        owl:onProperty brick:hasTag ] _:has_Occupancy _:has_Status ) ],
+        brick:Occupancy_Status ;
+    skos:definition "For systems that differentiate between scheduled occupied/unoccupied mode, this indicates if a space is temporarily occupied when it would otherwise be unoccupied"@en ;
+    brick:hasAssociatedTag tag:Occupancy,
+        tag:Point,
+        tag:Status,
+        tag:Temporary .
+
+brick:Thermal_Energy a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Thermal Energy" ;
+    qudt:applicableUnit unit:BTU_IT,
+        unit:BTU_TH,
+        unit:CAL_TH,
+        unit:KiloCAL,
+        unit:THM_US ;
+    owl:sameAs qudtqk:ThermalEnergy ;
+    skos:broader brick:Energy ;
+    skos:definition "Thermal Energy} is the portion of the thermodynamic or internal energy of a system that is responsible for the temperature of the system. From a macroscopic thermodynamic description, the thermal energy of a system is given by its constant volume specific heat capacity C(T), a temperature coefficient also called thermal capacity, at any given absolute temperature (T): (U_{thermal = C(T) \\cdot T)."@en .
+
+brick:Thermal_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Thermal Power",
+        "ThermalPower" ;
+    qudt:applicableUnit unit:BTU_IT,
+        unit:KiloW,
+        unit:MegaW,
+        unit:MilliW,
+        unit:W ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Power,
+        brick:Power ;
+    skos:definition "`"@en .
+
+brick:Thermal_Power_Meter a owl:Class ;
+    rdfs:label "Thermal Power Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment _:has_Thermal _:has_Power ) ],
+        brick:Meter ;
+    skos:definition "A standalone thermal power meter"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Meter,
+        tag:Power,
+        tag:Thermal .
+
+brick:Thermostat a owl:Class ;
+    rdfs:label "Thermostat" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Thermostat ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "An automatic control device used to maintain temperature at a fixed or adjustable setpoint."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Thermostat .
+
+brick:Ticketing_Booth a owl:Class ;
+    rdfs:label "Ticketing Booth" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Ticketing ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Booth ;
+                        owl:onProperty brick:hasTag ] _:has_Space _:has_Location ) ],
+        brick:Space ;
+    skos:definition "A room or space used to sell or distribute tickets to events at a venue"@en ;
+    brick:hasAssociatedTag tag:Booth,
+        tag:Location,
+        tag:Space,
+        tag:Ticketing .
+
+brick:Touchpanel a owl:Class ;
+    rdfs:label "Touchpanel" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface [ a owl:Restriction ;
+                        owl:hasValue tag:Touchpanel ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Interface ;
+    skos:definition "A switch used to operate all or part of a lighting installation that uses a touch-based mechanism (typically resistive or capacitive) rather than a mechanical actuator"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Interface,
+        tag:Touchpanel .
+
+brick:Trace_Heat_Sensor a owl:Class ;
+    rdfs:label "Trace Heat Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Trace ;
+                        owl:onProperty brick:hasTag ] _:has_Heat _:has_Sensor ) ],
+        brick:Heat_Sensor ;
+    skos:definition "Measures the surface temperature of pipelines carrying temperature-sensitive products; typically used to avoid frosting/freezing"@en ;
+    brick:hasAssociatedTag tag:Heat,
+        tag:Point,
+        tag:Sensor,
+        tag:Trace .
+
+brick:Transformer a owl:Class ;
+    rdfs:label "Transformer" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Transformer _:has_Equipment ) ],
+        brick:Electrical_Equipment ;
+    skos:definition "A Transformer is usually fed by a high-voltage source and then steps down the voltage to a lower-voltage feed for low-voltage application (such as lights). Transformers also can step up voltage, but this generally does not apply to in building distribution."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Transformer .
+
+brick:Transformer_Room a owl:Class ;
+    rdfs:label "Transformer Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Transformer _:has_Electrical _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Electrical_Room ;
+    skos:definition "An electrical room where electricity enters and is transformed to different voltages and currents by the equipment contained in the room"@en ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Location,
+        tag:Room,
+        tag:Service,
+        tag:Space,
+        tag:Transformer .
+
+brick:Tunnel a owl:Class ;
+    rdfs:label "Tunnel" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Tunnel ;
+                        owl:onProperty brick:hasTag ] _:has_Space _:has_Location ) ],
+        brick:Space ;
+    skos:definition "An enclosed space that connects buildings. Often underground"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Space,
+        tag:Tunnel .
+
+brick:Underfloor_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Underfloor Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Underfloor ;
+                        owl:onProperty brick:hasTag ] _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Air_Temperature_Sensor ;
+    skos:definition "Measures the temperature of underfloor air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Underfloor .
+
+brick:Unit_Failure_Alarm a owl:Class ;
+    rdfs:label "Unit Failure Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unit _:has_Failure _:has_Alarm ) ],
+        brick:Failure_Alarm ;
+    skos:definition "An alarm that indicates the failure of an equipment or device"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Failure,
+        tag:Point,
+        tag:Unit .
+
+brick:Unoccupied_Air_Temperature_Cooling_Setpoint a owl:Class ;
+    rdfs:label "Unoccupied Air Temperature Cooling Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Cool _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Cooling_Temperature_Setpoint,
+        brick:Unoccupied_Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of air when unoccupied for cooling"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Unoccupied .
+
+brick:Unoccupied_Air_Temperature_Heating_Setpoint a owl:Class ;
+    rdfs:label "Unoccupied Air Temperature Heating Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Heat _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Heating_Temperature_Setpoint,
+        brick:Unoccupied_Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of air when unoccupied for heating"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Unoccupied .
+
+brick:Unoccupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Unoccupied Cooling Discharge Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Cooling_Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets discharge air flow for cooling when unoccupied"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint,
+        tag:Unoccupied .
+
+brick:Unoccupied_Discharge_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Unoccupied Discharge Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Unoccupied ) ],
+        brick:Discharge_Air_Temperature_Setpoint,
+        brick:Unoccupied_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Unoccupied .
+
+brick:Unoccupied_Return_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Unoccupied Return Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Unoccupied ) ],
+        brick:Return_Air_Temperature_Setpoint,
+        brick:Unoccupied_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Point,
+        tag:Return,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Unoccupied .
+
+brick:Unoccupied_Room_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Unoccupied Room Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Room _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Unoccupied ) ],
+        brick:Room_Air_Temperature_Setpoint,
+        brick:Unoccupied_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Point,
+        tag:Room,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Unoccupied .
+
+brick:Unoccupied_Supply_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Unoccupied Supply Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Unoccupied ) ],
+        brick:Supply_Air_Temperature_Setpoint,
+        brick:Unoccupied_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Unoccupied .
+
+brick:Unoccupied_Zone_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Unoccupied Zone Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint _:has_Unoccupied ) ],
+        brick:Unoccupied_Air_Temperature_Setpoint,
+        brick:Zone_Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Unoccupied,
+        tag:Zone .
+
+brick:VFD_Enable_Command a owl:Class ;
+    rdfs:label "VFD Enable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_VFD ) ],
+        brick:Enable_Command ;
+    skos:definition "Enables operation of a variable frequency drive"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Enable,
+        tag:Point,
+        tag:VFD .
+
+brick:Valve_Command a owl:Class ;
+    rdfs:label "Valve Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Valve _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls or reports the openness of a valve (typically as a proportion of its full range of motion)"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Valve .
+
+brick:Valve_Position_Sensor a owl:Class ;
+    rdfs:label "Valve Position Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Valve _:has_Position _:has_Sensor ) ],
+        brick:Position_Sensor ;
+    skos:definition "Measures the current position of a valve in terms of the percent of fully open"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Position,
+        tag:Sensor,
+        tag:Valve .
+
+brick:Variable_Air_Volume_Box_With_Reheat a owl:Class ;
+    rdfs:label "Variable Air Volume Box With Reheat" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Variable _:has_Volume _:has_Box _:has_Reheat ) ],
+        brick:Variable_Air_Volume_Box ;
+    owl:equivalentClass brick:RVAV ;
+    skos:definition "A VAV box with a reheat coil mounted on the discharge end of the unit that can heat the air delivered to a zone"@en ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Equipment,
+        tag:Reheat,
+        tag:Variable,
+        tag:Volume .
+
+brick:Variable_Frequency_Drive a owl:Class ;
+    rdfs:label "Variable Frequency Drive" ;
+    rdfs:seeAlso <https://xp20.ashrae.org/terminology/index.php?term=vfd&submit=Search> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Variable _:has_Frequency _:has_Drive ) ],
+        brick:Motor ;
+    owl:equivalentClass brick:VFD ;
+    skos:definition "Electronic device that varies its output frequency to vary the rotating speed of a motor, given a fixed input frequency. Used with fans or pumps to vary the flow in the system as a function of a maintained pressure."@en ;
+    brick:hasAssociatedTag tag:Drive,
+        tag:Equipment,
+        tag:Frequency,
+        tag:Variable .
+
+brick:Velocity_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Velocity Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Velocity _:has_Pressure _:has_Setpoint ) ],
+        brick:Pressure_Setpoint ;
+    skos:definition "Sets static veloicty pressure"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Velocity .
+
+brick:Vent_Operating_Mode_Status a owl:Class ;
+    rdfs:label "Vent Operating Mode Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Vent ;
+                        owl:onProperty brick:hasTag ] _:has_Operating _:has_Mode _:has_Status ) ],
+        brick:Operating_Mode_Status ;
+    skos:definition "Indicates the current operating mode of a vent"@en ;
+    brick:hasAssociatedTag tag:Mode,
+        tag:Operating,
+        tag:Point,
+        tag:Status,
+        tag:Vent .
+
+brick:Ventilation_Air_Flow_Ratio_Limit a owl:Class ;
+    rdfs:label "Ventilation Air Flow Ratio Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Ventilation _:has_Air [ a owl:Restriction ;
+                        owl:hasValue tag:Ratio ;
+                        owl:onProperty brick:hasTag ] _:has_Limit ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Ventilation_Air_Flow_Ratio_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Limit,
+        tag:Point,
+        tag:Ratio,
+        tag:Ventilation .
+
+brick:Video_Intercom a owl:Class ;
+    rdfs:label "Video Intercom" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Security _:has_Intercom _:has_Video ) ],
+        brick:Intercom_Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Intercom,
+        tag:Security,
+        tag:Video .
+
+brick:Visitor_Lobby a owl:Class ;
+    rdfs:label "Visitor Lobby" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Visitor ;
+                        owl:onProperty brick:hasTag ] _:has_Lobby _:has_Common _:has_Space _:has_Location ) ],
+        brick:Lobby ;
+    skos:definition "A lobby for visitors to the building. Sometimes used to distinguish from an employee entrance looby"@en ;
+    brick:hasAssociatedTag tag:Common,
+        tag:Lobby,
+        tag:Location,
+        tag:Space,
+        tag:Visitor .
+
+brick:Voltage_Angle a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Voltage Angle",
+        "VoltageAngle" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Phasor_Angle ;
+    skos:definition "Angle of voltage phasor",
+        "Angle of voltage phasor"@en ;
+    skos:related brick:Voltage .
+
+brick:Voltage_Imbalance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Voltage Imbalance",
+        "VoltageImbalance" ;
+    qudt:applicableUnit unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Dimensionless ;
+    skos:definition "The percent deviation from average voltage",
+        "The percent deviation from average voltage"@en ;
+    skos:related brick:Voltage .
+
+brick:Wardrobe a owl:Class ;
+    rdfs:label "Wardrobe" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Wardrobe ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "Storage for clothing, costumes, or uniforms"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:Wardrobe .
+
+brick:Warm_Cool_Adjust_Sensor a owl:Class ;
+    rdfs:label "Warm Cool Adjust Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust [ a owl:Restriction ;
+                        owl:hasValue tag:Warm ;
+                        owl:onProperty brick:hasTag ] _:has_Cool ) ],
+        brick:Adjust_Sensor ;
+    skos:definition "User provided adjustment of zone temperature, typically in the range of +/- 5 degrees"@en ;
+    brick:hasAssociatedTag tag:Adjust,
+        tag:Cool,
+        tag:Point,
+        tag:Sensor,
+        tag:Warm .
+
+brick:Warmest_Zone_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Warmest Zone Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:Warmest ;
+                        owl:onProperty brick:hasTag ] _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Zone_Air_Temperature_Sensor ;
+    skos:definition "The zone temperature that is warmest; drives the supply temperature of cold air. A computed value rather than a physical sensor. Also referred to as a 'Highest Zone Air Temperature Sensor'"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Warmest,
+        tag:Zone .
+
+brick:Waste_Storage a owl:Class ;
+    rdfs:label "Waste Storage" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Waste ;
+                        owl:onProperty brick:hasTag ] _:has_Storage _:has_Room _:has_Space _:has_Location ) ],
+        brick:Storage_Room ;
+    skos:definition "A room used for storing waste such as trash or recycling"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:Storage,
+        tag:Waste .
+
+brick:Water_Distribution a owl:Class ;
+    rdfs:label "Water Distribution" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Distribution _:has_Equipment ) ],
+        brick:Equipment ;
+    skos:definition "Utilize a water distribution source to represent how water is distributed across multiple destinations (pipes)"@en ;
+    brick:hasAssociatedTag tag:Distribution,
+        tag:Equipment,
+        tag:Water .
+
+brick:Water_Loss_Alarm a owl:Class ;
+    rdfs:label "Water Loss Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Loss _:has_Water _:has_Alarm ) ],
+        brick:Water_Alarm ;
+    skos:definition "An alarm that indicates a loss of water e.g. during transport"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Loss,
+        tag:Point,
+        tag:Water .
+
+brick:Water_Tank a owl:Class ;
+    rdfs:label "Water Tank" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Tank _:has_Space _:has_Location ) ],
+        brick:Space ;
+    skos:definition "A space used to hold water"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Space,
+        tag:Tank,
+        tag:Water .
+
+brick:Weather_Condition a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Weather Condition" .
+
+brick:Weather_Station a owl:Class ;
+    rdfs:label "Weather Station" ;
+    rdfs:seeAlso <https://bedes.lbl.gov/bedes-online/weather-station> ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Weather ;
+                        owl:onProperty brick:hasTag ] _:has_Station _:has_Equipment ) ],
+        brick:Equipment ;
+    skos:definition "A dedicated weather measurement station"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Station,
+        tag:Weather .
+
+brick:Wind_Direction_Sensor a owl:Class ;
+    rdfs:label "Wind Direction Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Direction _:has_Wind ) ],
+        brick:Direction_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wind_Direction ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the direction of wind in degrees relative to North"@en ;
+    brick:hasAssociatedTag tag:Direction,
+        tag:Point,
+        tag:Sensor,
+        tag:Wind .
+
+brick:Wind_Speed_Sensor a owl:Class ;
+    rdfs:label "Wind Speed Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Speed _:has_Wind ) ],
+        brick:Speed_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wind_Speed ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measured speed of wind, caused by air moving from high to low pressure"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
+        tag:Speed,
+        tag:Wind .
+
+brick:Wing a owl:Class ;
+    rdfs:label "Wing" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Wing ;
+                        owl:onProperty brick:hasTag ] _:has_Location ) ],
+        brick:Location ;
+    skos:definition "A wing is part of a building – or any feature of a building – that is subordinate to the main, central structure."@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Wing .
+
+brick:Workshop a owl:Class ;
+    rdfs:label "Workshop" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Workshop ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A space used to house equipment that can be used to repair or fabricate things"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:Workshop .
+
+brick:Zone_Air_Cooling_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Zone Air Cooling Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Setpoint _:has_Cooling ) ],
+        brick:Cooling_Temperature_Setpoint,
+        brick:Zone_Air_Temperature_Setpoint ;
+    skos:definition "The upper (cooling) setpoint for zone air temperature"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cooling,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Zone .
+
+brick:Zone_Air_Dewpoint_Sensor a owl:Class ;
+    rdfs:label "Zone Air Dewpoint Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint _:has_Air _:has_Zone ) ],
+        brick:Dewpoint_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Dewpoint ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Zone_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures dewpoint of zone air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Dewpoint,
+        tag:Point,
+        tag:Sensor,
+        tag:Zone .
+
+brick:Zone_Air_Heating_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Zone Air Heating Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Setpoint [ a owl:Restriction ;
+                        owl:hasValue tag:Heating ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Heating_Temperature_Setpoint,
+        brick:Zone_Air_Temperature_Setpoint ;
+    skos:definition "The lower (heating) setpoint for zone air temperature"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Heating,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Zone .
+
+brick:Zone_Air_Humidity_Sensor a owl:Class ;
+    rdfs:label "Zone Air Humidity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Relative _:has_Air _:has_Zone ) ],
+        brick:Relative_Humidity_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Relative_Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Zone_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the relative humidity of zone air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Point,
+        tag:Relative,
+        tag:Sensor,
+        tag:Zone .
+
+brick:Zone_Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Zone Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air _:has_Zone ) ],
+        brick:Air_Humidity_Setpoint ;
+    skos:definition "Humidity setpoint for zone air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Point,
+        tag:Setpoint,
+        tag:Zone .
+
+brick:Zone_Standby_Load_Shed_Command a owl:Class ;
+    rdfs:label "Zone Standby Load Shed Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Standby_Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Standby,
+        tag:Zone .
+
+brick:Zone_Unoccupied_Load_Shed_Command a owl:Class ;
+    rdfs:label "Zone Unoccupied Load Shed Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Unoccupied_Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Unoccupied,
+        tag:Zone .
+
+brick:aggregate a brick:EntityProperty ;
+    rdfs:domain brick:Point ;
+    rdfs:range brick:AggregationShape ;
+    skos:definition "Description of how the dta for this point is aggregated" .
+
+brick:area a brick:EntityProperty ;
+    rdfs:domain brick:Location ;
+    rdfs:range brick:AreaShape ;
+    skos:definition "Entity has 2-dimensional area" .
+
+brick:buildingPrimaryFunction a brick:EntityProperty ;
+    rdfs:domain brick:Building ;
+    rdfs:range brick:BuildingPrimaryFunctionShape ;
+    rdfs:seeAlso "https://project-haystack.org/tag/primaryFunction" ;
+    skos:definition "Enumerated string applied to a site record to indicate the building's primary function. The list of primary functions is derived from the US Energy Star program (adopted from Project Haystack)" .
+
+brick:buildingThermalTransmittence a brick:EntityProperty ;
+    rdfs:domain brick:Building ;
+    rdfs:range brick:ThermalTransmittenceShape ;
+    rdfs:seeAlso "https://www.iso.org/obp/ui/#iso:std:iso:13789:ed-3:v1:en" ;
+    skos:definition "The area-weighted average heat transfer coefficient (commonly referred to as a U-value) for a building envelope" .
+
+brick:coolingCapacity a brick:EntityProperty ;
+    rdfs:domain brick:Chiller ;
+    rdfs:range brick:CoolingCapacityShape ;
+    rdfs:seeAlso "https://project-haystack.org/tag/coolingCapacity" ;
+    skos:definition "Measurement of a chiller ability to remove heat (adopted from Project Haystack)" .
+
+brick:currentFlowType a brick:EntityProperty ;
+    rdfs:range brick:CurrentFlowTypeShape ;
+    skos:definition "The current flow type of the entity" .
+
+brick:electricalPhaseCount a brick:EntityProperty ;
+    rdfs:range brick:PhaseCountShape ;
+    skos:definition "Entity has these phases" .
+
+brick:electricalPhases a brick:EntityProperty ;
+    rdfs:range brick:PhasesShape ;
+    skos:definition "Entity has these electrical AC phases" .
+
+brick:feedsAir a owl:ObjectProperty ;
+    rdfs:subPropertyOf brick:feeds ;
+    skos:definition "Passes air"@en .
+
+brick:grossArea a brick:EntityProperty ;
+    rdfs:domain brick:Location ;
+    rdfs:range brick:AreaShape ;
+    skos:definition "Entity has gross 2-dimensional area" .
+
+brick:hasAddress a owl:ObjectProperty ;
+    rdfs:domain brick:Building ;
+    rdfs:range vcard:Address ;
+    rdfs:subPropertyOf vcard:hasAddress ;
+    skos:definition "To specify the address of a building."@en .
+
+brick:hasInputSubstance a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:range brick:Substance ;
+    skos:definition "The subject receives the given substance as an input to its internal process"@en .
+
+brick:hasOutputSubstance a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:range brick:Substance ;
+    skos:definition "The subject produces or exports the given substance from its internal process"@en .
+
+brick:netArea a brick:EntityProperty ;
+    rdfs:domain brick:Location ;
+    rdfs:range brick:AreaShape ;
+    skos:definition "Entity has net 2-dimensional area" .
+
+brick:operationalStage a brick:EntityProperty ;
+    rdfs:range brick:StageShape ;
+    skos:definition "The associated operational stage" .
+
+brick:operationalStageCount a brick:EntityProperty ;
+    rdfs:domain brick:Equipment ;
+    rdfs:range brick:StageShape ;
+    skos:definition "The number of operational stages supported by this eqiupment" .
+
+brick:powerComplexity a brick:EntityProperty ;
+    rdfs:range brick:PowerComplexityShape ;
+    skos:definition "Entity has this power complexity" .
+
+brick:powerFlow a brick:EntityProperty ;
+    rdfs:range brick:PowerFlowShape ;
+    skos:definition "Entity has this power flow relative to the building'" .
+
+brick:regulates a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Equipment ;
+    rdfs:range brick:Substance ;
+    owl:inverseOf brick:isRegulatedBy ;
+    skos:definition "The subject contributes to or performs the regulation of the substance given by the object"@en .
+
+brick:thermalTransmittence a brick:EntityProperty ;
+    rdfs:range brick:ThermalTransmittenceShape ;
+    rdfs:seeAlso "https://www.iso.org/obp/ui/#iso:std:iso:13789:ed-3:v1:en" ;
+    skos:definition "The area-weighted average heat transfer coefficient (commonly referred to as a U-value)" .
+
+brick:timeseries a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Point ;
+    rdfs:range brick:TimeseriesReference ;
+    skos:definition "Relates a Brick point to the TimeseriesReference that indicates where and how the data for this point is stored"@en .
+
+brick:volume a brick:EntityProperty ;
+    rdfs:domain brick:Location ;
+    rdfs:range brick:VolumeShape ;
+    skos:definition "Entity has 3-dimensional volume" .
+
+brick:yearBuilt a brick:EntityProperty ;
+    rdfs:domain brick:Building ;
+    rdfs:range brick:YearBuiltShape ;
+    rdfs:seeAlso "https://project-haystack.org/tag/yearBuilt" ;
+    skos:definition "Four digit year that a building was first built. (adopted from Project Haystack)" .
+
+unit:A qudt:symbol "A" .
+
+unit:AMU qudt:symbol "\\(\\mu\\)" .
+
+unit:A_Ab qudt:symbol "abA" .
+
+unit:A_Stat qudt:symbol "statA" .
+
+unit:BARYE qudt:symbol "\\rho" .
+
+unit:BIOT qudt:symbol "Bi" .
+
+unit:BTU_TH qudt:symbol "Btu_{th}" .
+
+unit:CAL_TH qudt:symbol "cal_{th}" .
+
+unit:CD qudt:symbol "cd" .
+
+unit:CP qudt:symbol "cd" .
+
+unit:DAY qudt:symbol "d" .
+
+unit:DAY_Sidereal qudt:symbol "d" .
+
+unit:DEG_R qudt:symbol "°R",
+        "°Ra" .
+
+unit:DWT qudt:symbol "dwt" .
+
+unit:GM qudt:symbol "g" .
+
+unit:HP qudt:symbol "HP" .
+
+unit:HP_Water qudt:symbol "hp_water" .
+
+unit:HR qudt:symbol "hr" .
+
+unit:HR_Sidereal qudt:symbol "hr" .
+
+unit:KiloA qudt:symbol "kA" .
+
+unit:KiloCAL qudt:symbol "kcal" .
+
+unit:KiloGM qudt:symbol "kg" .
+
+unit:KiloSEC qudt:symbol "ks" .
+
+unit:LA qudt:symbol "L" .
+
+unit:LB_M qudt:symbol "lbm" .
+
+unit:LB_T qudt:symbol "lbt" .
+
+unit:LM qudt:symbol "lm" .
+
+unit:MIN qudt:symbol "min" .
+
+unit:MIN_Angle qudt:symbol "'" .
+
+unit:MIN_Sidereal qudt:symbol "min" .
+
+unit:MO qudt:symbol "mo" .
+
+unit:MicroA qudt:symbol "µA" .
+
+unit:MicroSEC qudt:symbol "microsec" .
+
+unit:MilliA qudt:symbol "mA" .
+
+unit:MilliSEC qudt:symbol "ms" .
+
+unit:N-M qudt:symbol "N-m" .
+
+unit:N-PER-M2 qudt:symbol "Pa" .
+
+unit:NanoA qudt:symbol "nA" .
+
+unit:NanoSEC qudt:symbol "ms" .
+
+unit:OZ_M qudt:symbol "ozm" .
+
+unit:OZ_TROY qudt:symbol "oz" .
+
+unit:PA qudt:symbol "Pa" .
+
+unit:PicoA qudt:symbol "pA" .
+
+unit:PlanckMass qudt:symbol "m_P" .
+
+unit:PlanckTime qudt:symbol "tP" .
+
+unit:SEC qudt:symbol "s" .
+
+unit:SH qudt:symbol "Sh" .
+
+unit:SLUG qudt:symbol "slug" .
+
+unit:STILB qudt:symbol "sb" .
+
+unit:SolarMass qudt:symbol "S" .
+
+unit:THM_US qudt:symbol "thm" .
+
+unit:TON_Assay qudt:symbol "AT" .
+
+unit:TON_LONG qudt:symbol "ton" .
+
+unit:TON_M qudt:symbol "mT" .
+
+unit:TON_SHORT qudt:symbol "ton" .
+
+unit:U qudt:symbol "u" .
+
+unit:WK qudt:symbol "wk" .
+
+unit:YR qudt:symbol "yr" .
+
+unit:YR_Sidereal qudt:symbol "yr" .
+
+unit:YR_TROPICAL qudt:symbol "a_{t}" .
+
+brick:AED a owl:Class ;
+    rdfs:label "AED" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Safety _:has_AED _:has_Defibrillator ) ],
+        brick:Safety_Equipment ;
+    owl:equivalentClass brick:Automated_External_Defibrillator ;
+    brick:hasAssociatedTag tag:AED,
+        tag:Defibrillator,
+        tag:Equipment,
+        tag:Safety .
+
+brick:Access_Control_Equipment a owl:Class ;
+    rdfs:label "Access Control Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Security _:has_Access _:has_Control ) ],
+        brick:Security_Equipment ;
+    brick:hasAssociatedTag tag:Access,
+        tag:Control,
+        tag:Equipment,
+        tag:Security .
+
+brick:Adjust_Sensor a owl:Class ;
+    rdfs:label "Adjust Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Adjust ) ],
+        brick:Sensor ;
+    skos:definition "Measures user-provided adjustment of some value"@en ;
+    brick:hasAssociatedTag tag:Adjust,
+        tag:Point,
+        tag:Sensor .
+
+brick:AggregationShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            skos:definition "Interval expressed in an ISO 8601 Duration string, e.g. RP1D" ;
+            sh:datatype xsd:string ;
+            sh:minCount 1 ;
+            sh:path brick:aggregationInterval ],
+        [ a sh:PropertyShape ;
+            sh:in ( "max" "min" "count" "mean" "sum" "median" "mode" ) ;
+            sh:minCount 1 ;
+            sh:path brick:aggregationFunction ] .
+
+brick:Air_Differential_Pressure_Sensor a owl:Class ;
+    rdfs:label "Air Differential Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Sensor _:has_Pressure _:has_Differential ) ],
+        brick:Differential_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the difference in pressure between two regions of air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor .
+
+brick:Air_Flow_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Air Flow Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Deadband _:has_Setpoint ) ],
+        brick:Air_Flow_Setpoint,
+        brick:Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of air flow"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Deadband,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Air_Handler_Unit a owl:Class ;
+    rdfs:label "Air Handler Unit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Air [ a owl:Restriction ;
+                        owl:hasValue tag:Handler ;
+                        owl:onProperty brick:hasTag ] _:has_Unit ) ],
+        brick:HVAC_Equipment ;
+    owl:equivalentClass brick:AHU,
+        brick:Air_Handling_Unit ;
+    skos:definition "Assembly consisting of sections containing a fan or fans and other necessary equipment to perform one or more of the following functions: circulating, filtration, heating, cooling, heat recovery, humidifying, dehumidifying, and mixing of air. Is usually connected to an air-distribution system."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Handler,
+        tag:Unit .
+
+brick:Air_Handling_Unit a owl:Class ;
+    rdfs:label "Air Handling Unit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Air [ a owl:Restriction ;
+                        owl:hasValue tag:Handling ;
+                        owl:onProperty brick:hasTag ] _:has_Unit ) ],
+        brick:HVAC_Equipment ;
+    owl:equivalentClass brick:AHU,
+        brick:Air_Handler_Unit ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Equipment,
+        tag:Handling,
+        tag:Unit .
+
+brick:Air_Static_Pressure_Step_Parameter a owl:Class ;
+    rdfs:label "Air Static Pressure Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
+        brick:Static_Pressure_Step_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Static,
+        tag:Step .
+
+brick:Air_Temperature_Setpoint_Limit a owl:Class ;
+    rdfs:label "Air Temperature Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+        brick:Limit,
+        brick:Temperature_Parameter ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Air_Temperature_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Limit,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Air_Wet_Bulb_Temperature_Sensor a owl:Class ;
+    rdfs:label "Air Wet Bulb Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Air _:has_Wet _:has_Bulb _:has_Temperature _:has_Sensor _:has_Point ) ],
+        brick:Air_Temperature_Sensor,
+        brick:Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Wet_Bulb_Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Bulb,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Wet .
+
+brick:Angle a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Angle" ;
+    qudt:applicableUnit unit:MIN_Angle ;
+    owl:sameAs qudtqk:Angle ;
+    skos:definition "The inclination to each other of two intersecting lines, measured by the arc of a circle intercepted between the two lines forming the angle, the center of the circle being the point of intersection.  An acute angle is less than (90^\\circ), a right angle (90^\\circ); an obtuse angle, more than (90^\\circ) but less than (180^\\circ); a straight angle, (180^\\circ); a reflex angle, more than (180^\\circ) but less than (360^\\circ); a perigon, (360^\\circ). Any angle not a multiple of (90^\\circ) is an oblique angle. If the sum of two angles is (90^\\circ), they are complementary angles; if (180^\\circ), supplementary angles; if (360^\\circ), explementary angles."@en .
+
+brick:Automated_External_Defibrillator a owl:Class ;
+    rdfs:label "Automated External Defibrillator" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Safety _:has_AED _:has_Defibrillator ) ],
+        brick:Safety_Equipment ;
+    owl:equivalentClass brick:AED ;
+    brick:hasAssociatedTag tag:AED,
+        tag:Defibrillator,
+        tag:Equipment,
+        tag:Safety .
+
+brick:Average_Discharge_Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Average Discharge Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Average _:has_Discharge _:has_Air _:has_Flow _:has_Sensor ) ],
+        brick:Discharge_Air_Flow_Sensor ;
+    skos:definition "The computed average flow of discharge air over some interval"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Average,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor .
+
+brick:Blowdown_Water a owl:Class,
+        brick:Blowdown_Water ;
+    rdfs:label "Blowdown Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water [ a owl:Restriction ;
+                        owl:hasValue tag:Blowdown ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Water ;
+    skos:definition "Water expelled from a system to remove mineral build up"@en ;
+    brick:hasAssociatedTag tag:Blowdown,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+brick:Break_Room a owl:Class ;
+    rdfs:label "Break Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Break ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    owl:equivalentClass brick:Breakroom ;
+    skos:definition "A space for people to relax while not working"@en ;
+    brick:hasAssociatedTag tag:Break,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:Breakroom a owl:Class ;
+    rdfs:label "Breakroom" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Breakroom ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    owl:equivalentClass brick:Break_Room ;
+    skos:definition "A space for people to relax while not working"@en ;
+    brick:hasAssociatedTag tag:Breakroom,
+        tag:Location,
+        tag:Room,
+        tag:Space .
+
+brick:BuildingPrimaryFunctionShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:in ( "Adult Education" "Ambulatory Surgical Center" "Aquarium" "Automobile Dealership" "Bank Branch" "Bar/Nightclub" "Barracks" "Bowling Alley" "Casino" "College/University" "Convenience Store with Gas Station" "Convenience Store without Gas Station" "Convention Center" "Courthouse" "Data Center" "Distribution Center" "Drinking Water Treatment & Distribution" "Enclosed Mall" "Energy/Power Station" "Fast Food Restaurant" "Financial Office" "Fire Station" "Fitness Center/Health Club/Gym" "Food Sales" "Food Service" "Hospital (General Medical & Surgical)" "Hotel" "Ice/Curling Rink" "Indoor Arena" "K-12 School" "Laboratory" "Library" "Lifestyle Center" "Mailing Center/Post Office" "Manufacturing/Industrial Plant" "Medical Office" "Mixed Use Property" "Movie Theater" "Multifamily Housing" "Museum" "Non-Refrigerated Warehouse" "Office" "Other - Education" "Other - Entertainment/Public Assembly" "Other - Lodging/Residential" "Other - Mall" "Other - Public Services" "Other - Recreation" "Other - Restaurant/Bar" "Other - Services" "Other - Stadium" "Other - Technology/Science" "Other - Utility" "Other" "Other/Specialty Hospital" "Outpatient Rehabilitation/Physical Therapy" "Parking" "Performing Arts" "Personal Services (Health/Beauty, Dry Cleaning, etc)" "Police Station" "Pre-school/Daycare" "Prison/Incarceration" "Race Track" "Refrigerated Warehouse" "Repair Services (Vehicle, Shoe, Locksmith, etc)" "Residence Hall/Dormitory" "Restaurant" "Retail Store" "Roller Rink" "Self-Storage Facility" "Senior Care Community" "Single Family Home" "Social/Meeting Hall" "Stadium (Closed)" "Stadium (Open)" "Strip Mall" "Supermarket/Grocery Store" "Swimming Pool" "Transportation Terminal/Station" "Urgent Care/Clinic/Other Outpatient" "Veterinary Office" "Vocational School" "Wastewater Treatment Plant" "Wholesale Club/Supercenter" "Worship Facility" "Zoo" ) ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:CAV a owl:Class ;
+    rdfs:label "CAV" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:CAV ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Terminal_Unit ;
+    brick:hasAssociatedTag tag:CAV,
+        tag:Equipment .
+
+brick:CO2_Alarm a owl:Class ;
+    rdfs:label "CO2 Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with the presence of carbon dioxide."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:CO2,
+        tag:Point .
+
+brick:CO2_Setpoint a owl:Class ;
+    rdfs:label "CO2 Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_CO2 _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets some property of CO2"@en ;
+    brick:hasAssociatedTag tag:CO2,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Camera a owl:Class ;
+    rdfs:label "Camera" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Camera _:has_Equipment ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Camera,
+        tag:Equipment .
+
+brick:Capacity a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Capacity" ;
+    owl:sameAs qudtqk:Capacity .
+
+brick:Chilled_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Chilled Water Differential Pressure Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+        brick:Chilled_Water_Differential_Pressure_Setpoint,
+        brick:Differential_Pressure_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of differential pressure of chilled water"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Deadband,
+        tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Chilled_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
+    rdfs:label "Chilled Water Differential Pressure Load Shed Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Load,
+        tag:Point,
+        tag:Pressure,
+        tag:Shed,
+        tag:Status,
+        tag:Water .
+
+brick:Chilled_Water_Discharge_Flow_Sensor a owl:Class ;
+    rdfs:label "Chilled Water Discharge Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Discharge _:has_Chilled ) ],
+        brick:Discharge_Water_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Discharge_Chilled_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of chilled discharge water"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor,
+        tag:Water .
+
+brick:Chilled_Water_Meter a owl:Class ;
+    rdfs:label "Chilled Water Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment _:has_Water _:has_Chilled ) ],
+        brick:Water_Meter ;
+    skos:definition "A meter that measures the usage or consumption of chilled water"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Equipment,
+        tag:Meter,
+        tag:Water .
+
+brick:Computer_Room_Air_Conditioning a owl:Class ;
+    rdfs:label "Computer Room Air Conditioning" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Computer ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Air _:has_Conditioning ) ],
+        brick:HVAC_Equipment ;
+    owl:equivalentClass brick:CRAC ;
+    skos:definition "A device that monitors and maintains the temperature, air distribution and humidity in a network room or data center."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Computer,
+        tag:Conditioning,
+        tag:Equipment,
+        tag:Room .
+
+brick:Conductivity_Sensor a owl:Class ;
+    rdfs:label "Conductivity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Conductivity ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Conductivity ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures electrical conductance"@en ;
+    brick:hasAssociatedTag tag:Conductivity,
+        tag:Point,
+        tag:Sensor .
+
+brick:CoolingCapacityShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:in ( unit:TON_FG unit:BTU_IT-PER-HR unit:BTU_TH-PER-HR unit:W ) ;
+            sh:minCount 1 ;
+            sh:path brick:hasUnit ],
+        [ a sh:PropertyShape ;
+            sh:datatype xsd:float ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:Cooling_Coil a owl:Class ;
+    rdfs:label "Cooling Coil" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Coil _:has_Cool ) ],
+        brick:Coil ;
+    skos:definition "A cooling element made of pipe or tube that removes heat from equipment, machines or airflows. Typically filled with either refrigerant or cold water."@en ;
+    brick:hasAssociatedTag tag:Coil,
+        tag:Cool,
+        tag:Equipment .
+
+brick:Cooling_Demand_Sensor a owl:Class ;
+    rdfs:label "Cooling Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Demand _:has_Cool ) ],
+        brick:Demand_Sensor ;
+    skos:definition "Measures the amount of power consumed by a cooling process; typically found by multiplying the tonnage of a unit (e.g. RTU) by the efficiency rating in kW/ton"@en ;
+    brick:hasAssociatedTag tag:Cool,
+        tag:Demand,
+        tag:Point,
+        tag:Sensor .
+
+brick:Cooling_Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Cooling Discharge Air Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Cooling_Setpoint,
+        brick:Discharge_Air_Temperature_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature of cooling discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Deadband,
+        tag:Discharge,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Cooling_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Cooling Discharge Air Temperature Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Air_Temperature_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Temperature,
+        tag:Time .
+
+brick:Cooling_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Cooling Discharge Air Temperature Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Discharge_Air_Temperature_Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:Cool,
+        tag:Discharge,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Temperature .
+
+brick:Cooling_Supply_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Cooling Supply Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Supply_Air_Flow_Setpoint ;
+    owl:equivalentClass brick:Cooling_Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets supply air flow rate for cooling"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:CurrentFlowTypeShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:in ( "AC" "DC" ) ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:Cycle_Alarm a owl:Class ;
+    rdfs:label "Cycle Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cycle _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates off-normal conditions associated with HVAC cycles"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Cycle,
+        tag:Point .
+
+brick:Damper_Command a owl:Class ;
+    rdfs:label "Damper Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Damper _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls properties of dampers"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Damper,
+        tag:Point .
+
+brick:Database a owl:Class ;
+    skos:definition "A database storing the timeseries data for the related point. Properties on this class are *to be determined*; feel free to add arbitrary properties onto Database instances for your particular deployment" .
+
+brick:Delay_Parameter a owl:Class ;
+    rdfs:label "Delay Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Delay _:has_Parameter ) ],
+        brick:Parameter ;
+    skos:definition "A parameter determining how long to delay a subsequent action to take place after a received signal"@en ;
+    brick:hasAssociatedTag tag:Delay,
+        tag:Parameter,
+        tag:Point .
+
+brick:Differential_Pressure_Step_Parameter a owl:Class ;
+    rdfs:label "Differential Pressure Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Step _:has_Parameter ) ],
+        brick:Step_Parameter ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Step .
+
+brick:Direction_Sensor a owl:Class ;
+    rdfs:label "Direction Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Direction ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Direction ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the direction in degrees in which a phenomenon is occuring"@en ;
+    brick:hasAssociatedTag tag:Direction,
+        tag:Point,
+        tag:Sensor .
+
+brick:Direction_Status a owl:Class ;
+    rdfs:label "Direction Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Direction _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates which direction a device is operating in"@en ;
+    brick:hasAssociatedTag tag:Direction,
+        tag:Point,
+        tag:Status .
+
+brick:Discharge_Air_Duct_Pressure_Status a owl:Class ;
+    rdfs:label "Discharge Air Duct Pressure Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Duct _:has_Pressure _:has_Status ) ],
+        brick:Pressure_Status ;
+    skos:definition "Indicates if air pressure in discharge duct is within expected bounds"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Duct,
+        tag:Point,
+        tag:Pressure,
+        tag:Status .
+
+brick:Discharge_Air_Flow_Demand_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Flow Demand Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
+        brick:Air_Flow_Demand_Setpoint,
+        brick:Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets the rate of discharge air flow required for a process"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Demand,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Discharge_Air_Humidity_Sensor a owl:Class ;
+    rdfs:label "Discharge Air Humidity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Relative _:has_Air _:has_Discharge ) ],
+        brick:Relative_Humidity_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Relative_Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Discharge_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the relative humidity of discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Humidity,
+        tag:Point,
+        tag:Relative,
+        tag:Sensor .
+
+brick:Discharge_Air_Static_Pressure_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Static Pressure Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+        brick:Discharge_Air_Static_Pressure_Setpoint,
+        brick:Static_Pressure_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of static pressure of discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Deadband,
+        tag:Discharge,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Discharge_Air_Static_Pressure_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Discharge Air Static Pressure Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Static_Pressure_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Static,
+        tag:Time .
+
+brick:Discharge_Air_Static_Pressure_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Discharge Air Static Pressure Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Static_Pressure_Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:Discharge,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Proportional,
+        tag:Static .
+
+brick:Discharge_Air_Static_Pressure_Sensor a owl:Class ;
+    rdfs:label "Discharge Air Static Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Discharge ) ],
+        brick:Static_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Static_Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Discharge_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "The static pressure of air within discharge regions of an HVAC system"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Static .
+
+brick:Discharge_Air_Temperature_Cooling_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Temperature Cooling Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Cool _:has_Setpoint ) ],
+        brick:Cooling_Temperature_Setpoint,
+        brick:Discharge_Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of discharge air for cooling"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Discharge_Air_Temperature_Heating_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Temperature Heating Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Heat _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Setpoint,
+        brick:Heating_Temperature_Setpoint ;
+    skos:definition "Sets temperature of discharge air for heating"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Discharge_Air_Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_High ) ],
+        brick:Discharge_Air_Temperature_Reset_Differential_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Discharge,
+        tag:High,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Discharge_Air_Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint _:has_Low ) ],
+        brick:Discharge_Air_Temperature_Reset_Differential_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Discharge,
+        tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Discharge_Air_Temperature_Step_Parameter a owl:Class ;
+    rdfs:label "Discharge Air Temperature Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
+        brick:Air_Temperature_Step_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Parameter,
+        tag:Point,
+        tag:Step,
+        tag:Temperature .
+
+brick:Discharge_Air_Velocity_Pressure_Sensor a owl:Class ;
+    rdfs:label "Discharge Air Velocity Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity _:has_Discharge _:has_Air ) ],
+        brick:Velocity_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Velocity_Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Discharge_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Velocity .
+
+brick:Discharge_Fan a owl:Class ;
+    rdfs:label "Discharge Fan" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan _:has_Discharge ) ],
+        brick:Fan ;
+    skos:definition "Fan moving air discharged from HVAC vents"@en ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Equipment,
+        tag:Fan .
+
+brick:Discharge_Water_Differential_Pressure_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Discharge Water Differential Pressure Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+        brick:Differential_Pressure_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of differential pressure of discharge water"@en ;
+    brick:hasAssociatedTag tag:Deadband,
+        tag:Differential,
+        tag:Discharge,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Discharge_Water_Temperature_Alarm a owl:Class ;
+    rdfs:label "Discharge Water Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Water _:has_Temperature _:has_Alarm ) ],
+        brick:Water_Temperature_Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with temperature of the discharge water."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Discharge,
+        tag:Point,
+        tag:Temperature,
+        tag:Water .
+
+brick:Domestic_Hot_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Domestic Hot Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Domestic _:has_Hot _:has_Water _:has_Temperature _:has_Setpoint ) ],
+        brick:Water_Temperature_Setpoint ;
+    skos:definition "Sets temperature of domestic hot water"@en ;
+    brick:hasAssociatedTag tag:Domestic,
+        tag:Hot,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+brick:Domestic_Water a owl:Class,
+        brick:Domestic_Water ;
+    rdfs:label "Domestic Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Domestic ) ],
+        brick:Water ;
+    skos:definition "Tap water for drinking, washing, cooking, and flushing of toliets"@en ;
+    brick:hasAssociatedTag tag:Domestic,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+brick:Dynamic_Pressure a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Dynamic Pressure" ;
+    skos:broader brick:Pressure .
+
+brick:Electric_Radiator a owl:Class ;
+    rdfs:label "Electric Radiator" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Radiator _:has_Electric ) ],
+        brick:Radiator ;
+    skos:definition "Electric heating device"@en ;
+    brick:hasAssociatedTag tag:Electric,
+        tag:Equipment,
+        tag:Radiator .
+
+brick:Electrical_Meter a owl:Class ;
+    rdfs:label "Electrical Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_Meter _:has_Equipment ) ],
+        brick:Meter ;
+    skos:definition "A meter that measures the usage or consumption of electricity"@en ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Equipment,
+        tag:Meter .
+
+brick:Elevator_Shaft a owl:Class ;
+    rdfs:label "Elevator Shaft" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Elevator _:has_Vertical [ a owl:Restriction ;
+                        owl:hasValue tag:Shaft ;
+                        owl:onProperty brick:hasTag ] _:has_Space _:has_Location ) ],
+        brick:Vertical_Space ;
+    owl:equivalentClass brick:Elevator_Space ;
+    skos:definition "The vertical space in which an elevator ascends and descends"@en ;
+    brick:hasAssociatedTag tag:Elevator,
+        tag:Location,
+        tag:Shaft,
+        tag:Space,
+        tag:Vertical .
+
+brick:Elevator_Space a owl:Class ;
+    rdfs:label "Elevator Space" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Elevator _:has_Vertical _:has_Space _:has_Location ) ],
+        brick:Vertical_Space ;
+    owl:equivalentClass brick:Elevator_Shaft ;
+    skos:definition "The vertical space in whcih an elevator ascends and descends"@en ;
+    brick:hasAssociatedTag tag:Elevator,
+        tag:Location,
+        tag:Space,
+        tag:Vertical .
+
+brick:Emergency_Alarm a owl:Class ;
+    rdfs:label "Emergency Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "Alarms that indicate off-normal conditions associated with emergency systems"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Emergency,
+        tag:Point .
+
+brick:Enable_Status a owl:Class ;
+    rdfs:label "Enable Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if a system or piece of functionality has been enabled"@en ;
+    brick:hasAssociatedTag tag:Enable,
+        tag:Point,
+        tag:Status .
+
+brick:Energy_Sensor a owl:Class ;
+    rdfs:label "Energy Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Energy ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Energy ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures energy consumption"@en ;
+    brick:hasAssociatedTag tag:Energy,
+        tag:Point,
+        tag:Sensor .
+
+brick:Energy_Storage a owl:Class ;
+    rdfs:label "Energy Storage" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Energy _:has_Storage _:has_Equipment ) ],
+        brick:Electrical_Equipment ;
+    skos:definition "Devices or equipment that store energy in its various forms"@en ;
+    brick:hasAssociatedTag tag:Energy,
+        tag:Equipment,
+        tag:Storage .
+
+brick:Enthalpy_Sensor a owl:Class ;
+    rdfs:label "Enthalpy Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Enthalpy ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Enthalpy ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the total heat content of some substance"@en ;
+    brick:hasAssociatedTag tag:Enthalpy,
+        tag:Point,
+        tag:Sensor .
+
+brick:Exhaust_Air_Flow_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Exhaust Air Flow Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Flow _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Flow,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Time .
+
+brick:Exhaust_Air_Flow_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Exhaust Air Flow Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Flow _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:Exhaust,
+        tag:Flow,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional .
+
+brick:Exhaust_Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Exhaust Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Exhaust ) ],
+        brick:Air_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Exhaust_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of exhaust air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor .
+
+brick:Exhaust_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Exhaust Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Air_Flow_Setpoint ;
+    skos:definition "Sets exhaust air flow rate"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Exhaust_Air_Stack_Flow_Setpoint a owl:Class ;
+    rdfs:label "Exhaust Air Stack Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Exhaust _:has_Air _:has_Stack _:has_Flow _:has_Setpoint ) ],
+        brick:Exhaust_Air_Flow_Setpoint ;
+    skos:definition "Sets exhaust air stack flow rate"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint,
+        tag:Stack .
+
+brick:FCU a owl:Class ;
+    rdfs:label "FCU" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:FCU ;
+                        owl:onProperty brick:hasTag ] _:has_Equipment ) ],
+        brick:Terminal_Unit ;
+    skos:definition "See Fan_Coil_Unit"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:FCU .
+
+brick:Failure_Alarm a owl:Class ;
+    rdfs:label "Failure Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Failure _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "Alarms that indicate the failure of devices, equipment, systems and control loops"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Failure,
+        tag:Point .
+
+brick:Fan_Status a owl:Class ;
+    rdfs:label "Fan Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fan _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates properties of fans"@en ;
+    brick:hasAssociatedTag tag:Fan,
+        tag:Point,
+        tag:Status .
+
+brick:Filter_Status a owl:Class ;
+    rdfs:label "Filter Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Filter _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if a filter needs to be replaced"@en ;
+    brick:hasAssociatedTag tag:Filter,
+        tag:Point,
+        tag:Status .
+
+brick:Fire_Safety_Equipment a owl:Class ;
+    rdfs:label "Fire Safety Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fire _:has_Safety _:has_Equipment ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fire,
+        tag:Safety .
+
+brick:Flow_Setpoint a owl:Class ;
+    rdfs:label "Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Flow _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets flow"@en ;
+    brick:hasAssociatedTag tag:Flow,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Food_Service_Room a owl:Class ;
+    rdfs:label "Food Service Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Food _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A space used in the production, storage, serving, or cleanup of food and beverages"@en ;
+    brick:hasAssociatedTag tag:Food,
+        tag:Location,
+        tag:Room,
+        tag:Service,
+        tag:Space .
+
+brick:Formaldehyde_Concentration a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Formaldehyde Concentration",
+        "FormaldehydeConcentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration of formaldehyde in air" .
+
+brick:Frequency_Command a owl:Class ;
+    rdfs:label "Frequency Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fequency _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls the frequency of a device's operation (e.g. rotational frequency)"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Fequency,
+        tag:Point .
+
+brick:Frequency_Sensor a owl:Class ;
+    rdfs:label "Frequency Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Frequency ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Frequency ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the frequency of a phenomenon or aspect of a phenomenon, e.g. the frequency of a fan turning"@en ;
+    brick:hasAssociatedTag tag:Frequency,
+        tag:Point,
+        tag:Sensor .
+
+brick:Fresh_Air_Setpoint_Limit a owl:Class ;
+    rdfs:label "Fresh Air Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fresh _:has_Air _:has_Limit _:has_Setpoint ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Fresh_Air_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Fresh,
+        tag:Limit,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Fuel_Oil a owl:Class,
+        brick:Fuel_Oil ;
+    rdfs:label "Fuel Oil" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Oil [ a owl:Restriction ;
+                        owl:hasValue tag:Fuel ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Oil ;
+    skos:definition "Petroleum based oil burned for energy"@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Fuel,
+        tag:Liquid,
+        tag:Oil .
+
+brick:Gas_Meter a owl:Class ;
+    rdfs:label "Gas Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment _:has_Gas ) ],
+        brick:Meter ;
+    skos:definition "A meter that measures the usage or consumption of gas"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Gas,
+        tag:Meter .
+
+brick:Gasoline a owl:Class,
+        brick:Gasoline ;
+    rdfs:label "Gasoline" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid [ a owl:Restriction ;
+                        owl:hasValue tag:Gasoline ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Liquid ;
+    skos:definition "Petroleum derived liquid used as a fuel source"@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Gasoline,
+        tag:Liquid .
+
+brick:Glycol a owl:Class,
+        brick:Glycol ;
+    rdfs:label "Glycol" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid [ a owl:Restriction ;
+                        owl:hasValue tag:Glycol ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Liquid ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Glycol,
+        tag:Liquid .
+
+brick:HVAC_System a owl:Class ;
+    rdfs:label "HVAC System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_HVAC _:has_System ) ],
+        brick:System ;
+    brick:hasAssociatedTag tag:HVAC,
+        tag:System .
+
+brick:HX a owl:Class ;
+    rdfs:label "HX" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:HX ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "See Heat_Exchanger"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:HX .
+
+brick:Heat_Sensor a owl:Class ;
+    rdfs:label "Heat Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Heat ) ],
+        brick:Sensor ;
+    skos:definition "Measures heat"@en ;
+    brick:hasAssociatedTag tag:Heat,
+        tag:Point,
+        tag:Sensor .
+
+brick:Heating_Coil a owl:Class ;
+    rdfs:label "Heating Coil" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Coil _:has_Heat ) ],
+        brick:Coil ;
+    skos:definition "A heating element typically made of pipe, tube or wire that emits heat. Typically filled with hot water, or, in the case of wire, uses electricity."@en ;
+    brick:hasAssociatedTag tag:Coil,
+        tag:Equipment,
+        tag:Heat .
+
+brick:Heating_Demand_Sensor a owl:Class ;
+    rdfs:label "Heating Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Demand _:has_Heat ) ],
+        brick:Demand_Sensor ;
+    skos:definition "Measures the amount of power consumed by a heating process; typically found by multiplying the tonnage of a unit (e.g. RTU) by the efficiency rating in kW/ton"@en ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Heat,
+        tag:Point,
+        tag:Sensor .
+
+brick:Heating_Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Heating Discharge Air Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Deadband_Setpoint,
+        brick:Discharge_Air_Temperature_Heating_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature of heating discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Deadband,
+        tag:Discharge,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Heating_Discharge_Air_Temperature_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Heating Discharge Air Temperature Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Discharge _:has_Air _:has_Temperature _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Air_Temperature_Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Heat,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Temperature,
+        tag:Time .
+
+brick:Heating_Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Heating Discharge Air Temperature Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Discharge_Air_Temperature_Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:Discharge,
+        tag:Heat,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Temperature .
+
+brick:Heating_Supply_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Heating Supply Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Supply_Air_Flow_Setpoint ;
+    owl:equivalentClass brick:Heating_Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets supply air flow rate for heating"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
+    rdfs:label "Hot Water Differential Pressure Load Shed Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Load,
+        tag:Point,
+        tag:Pressure,
+        tag:Shed,
+        tag:Status,
+        tag:Water .
+
+brick:Hot_Water_Differential_Pressure_Sensor a owl:Class ;
+    rdfs:label "Hot Water Differential Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential _:has_Water _:has_Hot ) ],
+        brick:Differential_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Hot_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the difference in water pressure on either side of a hot water valve"@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Water .
+
+brick:Hot_Water_Differential_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Hot Water Differential Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+        brick:Differential_Pressure_Setpoint ;
+    skos:definition "Sets differential pressure of hot water"@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Hot,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Hot_Water_Meter a owl:Class ;
+    rdfs:label "Hot Water Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment _:has_Water _:has_Hot ) ],
+        brick:Water_Meter ;
+    skos:definition "A meter that measures the usage or consumption of hot water"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Hot,
+        tag:Meter,
+        tag:Water .
+
+brick:Hot_Water_Radiator a owl:Class ;
+    rdfs:label "Hot Water Radiator" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Radiator _:has_Hot _:has_Water ) ],
+        brick:Radiator ;
+    skos:definition "Radiator that uses hot water"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Hot,
+        tag:Radiator,
+        tag:Water .
+
+brick:Hot_Water_Supply_Temperature_Load_Shed_Status a owl:Class ;
+    rdfs:label "Hot Water Supply Temperature Load Shed Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Status,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Hot_Water_System_Enable_Command a owl:Class ;
+    rdfs:label "Hot Water System Enable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_Hot _:has_Water _:has_System ) ],
+        brick:System_Enable_Command ;
+    skos:definition "Enables operation of the hot water system"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Enable,
+        tag:Hot,
+        tag:Point,
+        tag:System,
+        tag:Water .
+
+brick:Humidity_Sensor a owl:Class ;
+    rdfs:label "Humidity Sensor" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Humidity> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Humidity ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the concentration of water vapor in air"@en ;
+    brick:hasAssociatedTag tag:Humidity,
+        tag:Point,
+        tag:Sensor .
+
+brick:Humidity_Setpoint a owl:Class ;
+    rdfs:label "Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets humidity"@en ;
+    brick:hasAssociatedTag tag:Humidity,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Ice a owl:Class,
+        brick:Ice ;
+    rdfs:label "Ice" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Ice ) ],
+        brick:Solid ;
+    skos:definition "Water in its solid form"@en ;
+    brick:hasAssociatedTag tag:Ice,
+        tag:Solid .
+
+brick:Illuminance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Illuminance" ;
+    owl:sameAs qudtqk:Illuminance .
+
+brick:Illuminance_Sensor a owl:Class ;
+    rdfs:label "Illuminance Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Illuminance ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Illuminance ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the total luminous flux incident on a surface, per unit area"@en ;
+    brick:hasAssociatedTag tag:Illuminance,
+        tag:Point,
+        tag:Sensor .
+
+brick:Integral_Gain_Parameter a owl:Class ;
+    rdfs:label "Integral Gain Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Integral ) ],
+        brick:Gain_Parameter ;
+    brick:hasAssociatedTag tag:Gain,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point .
+
+brick:Irradiance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Irradiance" ;
+    qudt:applicableUnit unit:W-PER-CeniM2,
+        unit:W-PER-FT2,
+        unit:W-PER-IN2,
+        unit:W-PER-M2 ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:PowerPerArea ;
+    skos:definition "The power per unit area of electromagnetic radiation incident on a surface",
+        "The power per unit area of electromagnetic radiation incident on a surface"@en .
+
+brick:Isolation_Valve a owl:Class ;
+    rdfs:label "Isolation Valve" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Isolation_valve> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Isolation _:has_Valve _:has_Equipment ) ],
+        brick:Valve ;
+    skos:definition "A valve that stops the flow of a fluid, usually for maintenance or safety purposes"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Isolation,
+        tag:Valve .
+
+brick:Leak_Alarm a owl:Class ;
+    rdfs:label "Leak Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Leak _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates leaks occured in systems containing fluids"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Leak,
+        tag:Point .
+
+brick:Leaving_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Leaving Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Leaving ) ],
+        brick:Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Leaving_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of water leaving a condenser"@en ;
+    brick:hasAssociatedTag tag:Leaving,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Liquid_CO2 a owl:Class,
+        brick:Liquid_CO2 ;
+    rdfs:label "Liquid CO2" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_CO2 ) ],
+        brick:Liquid ;
+    skos:definition "Carbon Dioxide in the liquid phase"@en ;
+    brick:hasAssociatedTag tag:CO2,
+        tag:Fluid,
+        tag:Liquid .
+
+brick:Load_Parameter a owl:Class ;
+    rdfs:label "Load Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Parameter ) ],
+        brick:Parameter ;
+    brick:hasAssociatedTag tag:Load,
+        tag:Parameter,
+        tag:Point .
+
+brick:Load_Setpoint a owl:Class ;
+    rdfs:label "Load Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Setpoint ) ],
+        brick:Setpoint ;
+    brick:hasAssociatedTag tag:Load,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Load_Shed_Differential_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Load Shed Differential Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Shed _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+        brick:Differential_Pressure_Setpoint,
+        brick:Load_Shed_Setpoint ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Load,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Shed .
+
+brick:Lockout_Temperature_Differential_Parameter a owl:Class ;
+    rdfs:label "Lockout Temperature Differential Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Lockout _:has_Temperature _:has_Differential _:has_Sensor ) ],
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Lockout,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Lounge a owl:Class ;
+    rdfs:label "Lounge" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lounge _:has_Common _:has_Space _:has_Location ) ],
+        brick:Common_Space ;
+    skos:definition "A room for lesiure activities or relaxing"@en ;
+    brick:hasAssociatedTag tag:Common,
+        tag:Location,
+        tag:Lounge,
+        tag:Space .
+
+brick:Low_Temperature_Alarm a owl:Class ;
+    rdfs:label "Low Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Low _:has_Temperature _:has_Alarm ) ],
+        brick:Temperature_Alarm ;
+    skos:definition "An alarm that indicates low temperature."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Low,
+        tag:Point,
+        tag:Temperature .
+
+brick:Makeup_Water a owl:Class,
+        brick:Makeup_Water ;
+    rdfs:label "Makeup Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Makeup ) ],
+        brick:Water ;
+    skos:definition "Water used used to makeup water loss through leaks, evaporation, or blowdown"@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Makeup,
+        tag:Water .
+
+brick:Mass a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Mass" ;
+    qudt:applicableUnit unit:AMU,
+        unit:DWT,
+        unit:GM,
+        unit:GRAIN,
+        unit:KiloGM,
+        unit:LB_M,
+        unit:LB_T,
+        unit:OZ_M,
+        unit:OZ_TROY,
+        unit:PlanckMass,
+        unit:SLUG,
+        unit:SolarMass,
+        unit:TON_Assay,
+        unit:TON_LONG,
+        unit:TON_M,
+        unit:TON_SHORT,
+        unit:U ;
+    owl:sameAs qudtqk:Mass .
+
+brick:Max_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Discharge Air Static Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Limit,
+        brick:Max_Static_Pressure_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Discharge_Air_Static_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Max_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Occupied Cooling Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Occupied_Cooling_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Flow,
+        tag:Limit,
+        tag:Max,
+        tag:Occupied,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Max_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Occupied Heating Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Occupied _:has_Heat _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Occupied_Heating_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Max,
+        tag:Occupied,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Max_Temperature_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Temperature Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+        brick:Max_Limit,
+        brick:Temperature_Parameter ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Temperature_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Max,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Max_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Unoccupied Cooling Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Unoccupied_Cooling_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Flow,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Unoccupied .
+
+brick:Max_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Unoccupied Heating Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Unoccupied _:has_Heat _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Unoccupied_Heating_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Unoccupied .
+
+brick:Mechanical_Room a owl:Class ;
+    rdfs:label "Mechanical Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Mechanical _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Service_Room ;
+    skos:definition "A class of service rooms where mechanical equipment (HVAC) operates"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Mechanical,
+        tag:Room,
+        tag:Service,
+        tag:Space .
+
+brick:Medical_Room a owl:Class ;
+    rdfs:label "Medical Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Medical ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A class of rooms used for medical purposes"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Medical,
+        tag:Room,
+        tag:Space .
+
+brick:Medium_Temperature_Hot_Water_Differential_Pressure_Load_Shed_Status a owl:Class ;
+    rdfs:label "Medium Temperature Hot Water Differential Pressure Load Shed Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Medium _:has_Temperature _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Differential_Pressure_Load_Shed_Status ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Load,
+        tag:Medium,
+        tag:Point,
+        tag:Pressure,
+        tag:Shed,
+        tag:Status,
+        tag:Temperature .
+
+brick:Min_Discharge_Air_Static_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Discharge Air Static Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Limit,
+        brick:Min_Static_Pressure_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Discharge_Air_Static_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Min_Occupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Occupied Cooling Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Occupied_Cooling_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Flow,
+        tag:Limit,
+        tag:Min,
+        tag:Occupied,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Min_Occupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Occupied Heating Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Occupied _:has_Heat _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Occupied_Heating_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Min,
+        tag:Occupied,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Min_Temperature_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Temperature Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+        brick:Min_Limit,
+        brick:Temperature_Parameter ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Temperature_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Min,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Min_Unoccupied_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Unoccupied Cooling Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Unoccupied_Cooling_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Flow,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Unoccupied .
+
+brick:Min_Unoccupied_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Unoccupied Heating Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Unoccupied _:has_Heat _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Unoccupied_Heating_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Unoccupied .
+
+brick:Motion_Sensor a owl:Class ;
+    rdfs:label "Motion Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor [ a owl:Restriction ;
+                        owl:hasValue tag:Motion ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Sensor ;
+    skos:definition "Detects the presence of motion in some area"@en ;
+    brick:hasAssociatedTag tag:Motion,
+        tag:Point,
+        tag:Sensor .
+
+brick:NVR a owl:Class ;
+    rdfs:label "NVR" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Security _:has_Video _:has_Surveillance _:has_NVR ) ],
+        brick:Video_Surveillance_Equipment ;
+    owl:equivalentClass brick:Network_Video_Recorder ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:NVR,
+        tag:Security,
+        tag:Surveillance,
+        tag:Video .
+
+brick:Natural_Gas a owl:Class,
+        brick:Natural_Gas ;
+    rdfs:label "Natural Gas" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas [ a owl:Restriction ;
+                        owl:hasValue tag:Natural ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Gas ;
+    skos:definition "Fossil fuel energy source consisting largely of methane and other hydrocarbons"@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Gas,
+        tag:Natural .
+
+brick:Network_Video_Recorder a owl:Class ;
+    rdfs:label "Network Video Recorder" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_NVR _:has_Equipment _:has_Security _:has_Video [ a owl:Restriction ;
+                        owl:hasValue tag:Recorder ;
+                        owl:onProperty brick:hasTag ] [ a owl:Restriction ;
+                        owl:hasValue tag:Network ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Video_Surveillance_Equipment ;
+    owl:equivalentClass brick:NVR ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:NVR,
+        tag:Network,
+        tag:Recorder,
+        tag:Security,
+        tag:Video .
+
+brick:Occupancy_Sensor a owl:Class ;
+    rdfs:label "Occupancy Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Occupancy ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Occupancy ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Detects occupancy of some space or area"@en ;
+    brick:hasAssociatedTag tag:Occupancy,
+        tag:Point,
+        tag:Sensor .
+
+brick:Occupancy_Status a owl:Class ;
+    rdfs:label "Occupancy Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupancy _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if a room or space is occupied"@en ;
+    brick:hasAssociatedTag tag:Occupancy,
+        tag:Point,
+        tag:Status .
+
+brick:Occupied_Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Occupied Cooling Discharge Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Cooling_Discharge_Air_Flow_Setpoint,
+        brick:Occupied_Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets discharge air flow for cooling when occupied"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Flow,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Occupied_Heating_Discharge_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Occupied Heating Discharge Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Heat _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Heating_Discharge_Air_Flow_Setpoint,
+        brick:Occupied_Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets discharge air flow for heating when occupied"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Heat,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Operating_Mode_Status a owl:Class ;
+    rdfs:label "Operating Mode Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Operating _:has_Mode _:has_Status ) ],
+        brick:Mode_Status ;
+    skos:definition "Indicates the current operating mode of a system, device or control loop"@en ;
+    brick:hasAssociatedTag tag:Mode,
+        tag:Operating,
+        tag:Point,
+        tag:Status .
+
+brick:Outside_Air_Temperature_Enable_Differential_Sensor a owl:Class ;
+    rdfs:label "Outside Air Temperature Enable Differential Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Enable _:has_Differential _:has_Sensor ) ],
+        brick:Outside_Air_Temperature_Sensor ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Enable,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Override_Command a owl:Class ;
+    rdfs:label "Override Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Override _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls or reports whether or not a device or control loop is in 'override'"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Override,
+        tag:Point .
+
+brick:PM10_Concentration a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "PM10 Concentration",
+        "PM10Concentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration of particulates with diameter of 10 microns or less in air" .
+
+brick:PM10_Sensor a owl:Class ;
+    rdfs:label "PM10 Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Particulate _:has_Matter _:has_PM10 ) ],
+        brick:Particulate_Matter_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:PM10_Concentration ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Detects matter of size 10 microns"@en ;
+    brick:hasAssociatedTag tag:Matter,
+        tag:PM10,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor .
+
+brick:PM1_Concentration a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "PM1 Concentration",
+        "PM1Concentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration of particulates with diameter of 1 microns or less in air" .
+
+brick:PM1_Sensor a owl:Class ;
+    rdfs:label "PM1 Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Particulate _:has_Matter _:has_PM1 ) ],
+        brick:Particulate_Matter_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:PM1_Concentration ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Detects matter of size 1 micron"@en ;
+    brick:hasAssociatedTag tag:Matter,
+        tag:PM1,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor .
+
+brick:PM2.5_Concentration a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "PM2.5 Concentration",
+        "PM2.5Concentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration of particulates with diameter of 2.5 microns or less in air" .
+
+brick:PM2.5_Sensor a owl:Class ;
+    rdfs:label "PM2.5 Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Particulate _:has_Matter _:has_PM2.5 ) ],
+        brick:Particulate_Matter_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:PM2.5_Concentration ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Detects matter of size 2.5 microns"@en ;
+    brick:hasAssociatedTag tag:Matter,
+        tag:PM2.5,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor .
+
+brick:PV_Current_Output_Sensor a owl:Class ;
+    rdfs:label "PV Current Output Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point [ a owl:Restriction ;
+                        owl:hasValue tag:PV ;
+                        owl:onProperty brick:hasTag ] _:has_Current _:has_Output _:has_Sensor ) ],
+        brick:Current_Output_Sensor ;
+    skos:definition "See Photovoltaic_Current_Output_Sensor"@en ;
+    brick:hasAssociatedTag tag:Current,
+        tag:Output,
+        tag:PV,
+        tag:Point,
+        tag:Sensor .
+
+brick:Peak_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Peak Power",
+        "PeakPower" ;
+    qudt:applicableUnit unit:KiloW,
+        unit:MegaW,
+        unit:MilliW,
+        unit:W ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-3D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Power,
+        brick:Power ;
+    skos:definition "Tracks the highest (peak) observed power in some interval",
+        "Tracks the highest (peak) observed power in some interval"@en .
+
+brick:PhaseCountShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:in ( "1" "2" "3" "Total" ) ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:PhasesShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:in ( "A" "B" "C" "AB" "BC" "AC" "ABC" ) ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:Position a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Position" ;
+    qudt:applicableUnit unit:PERCENT ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless ;
+    skos:definition "The fraction of the full range of motion",
+        "The fraction of the full range of motion"@en .
+
+brick:Position_Command a owl:Class ;
+    rdfs:label "Position Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls or reports the position of some object"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Position .
+
+brick:Potable_Water a owl:Class,
+        brick:Potable_Water ;
+    rdfs:label "Potable Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water [ a owl:Restriction ;
+                        owl:hasValue tag:Potable ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Water ;
+    skos:definition "Water that is safe to drink"@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Potable,
+        tag:Water .
+
+brick:PowerComplexityShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:in ( "real" "reactive" "apparent" ) ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:PowerFlowShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:in ( "import" "export" "net" "absolute" ) ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:Power_Alarm a owl:Class ;
+    rdfs:label "Power Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Power _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with electrical power."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
+        tag:Power .
+
+brick:Precipitation a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Precipitation" ;
+    qudt:applicableUnit unit:CentiM,
+        unit:DeciM,
+        unit:FT,
+        unit:IN,
+        unit:KiloM,
+        unit:M,
+        unit:MicroM,
+        unit:MilliM,
+        unit:YD ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Length,
+        brick:Level ;
+    skos:definition "Amount of atmospheric water vapor fallen including rain, sleet, snow, and hail (https://project-haystack.dev/doc/lib-phScience/precipitation)",
+        "Amount of atmospheric water vapor fallen including rain, sleet, snow, and hail (https://project-haystack.dev/doc/lib-phScience/precipitation)"@en .
+
+brick:Preheat_Discharge_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Preheat Discharge Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Preheat _:has_Discharge _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Discharge_Air_Temperature_Sensor ;
+    skos:definition "Measures the temperature of discharge air before heating is applied"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Point,
+        tag:Preheat,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Proportional_Gain_Parameter a owl:Class ;
+    rdfs:label "Proportional Gain Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain _:has_Proportional ) ],
+        brick:Gain_Parameter ;
+    brick:hasAssociatedTag tag:Gain,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional .
+
+brick:Pump a owl:Class ;
+    rdfs:label "Pump" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "Machine for imparting energy to a fluid, causing it to do work, drawing a fluid into itself through an entrance port, and forcing the fluid out through an exhaust port."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Pump .
+
+brick:RTU a owl:Class ;
+    rdfs:label "RTU" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:RTU ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:AHU ;
+    owl:equivalentClass brick:Rooftop_Unit ;
+    skos:definition "see Rooftop_Unit"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:RTU .
+
+brick:RVAV a owl:Class ;
+    rdfs:label "RVAV" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:RVAV ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Variable_Air_Volume_Box ;
+    skos:definition "See Variable_Air_Volume_Box_With_Reheat"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:RVAV .
+
+brick:Radiance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Radiance" ;
+    owl:sameAs qudtqk:Radiance .
+
+brick:Rain_Sensor a owl:Class ;
+    rdfs:label "Rain Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Rain ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Precipitation ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the amount of precipitation fallen"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Rain,
+        tag:Sensor .
+
+brick:Reactive_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Reactive Power" ;
+    owl:sameAs qudtqk:ReactivePower ;
+    skos:broader brick:Electric_Power ;
+    skos:definition "Reactive Power}, for a linear two-terminal element or two-terminal circuit, under sinusoidal conditions, is the quantity equal to the product of the apparent power (S) and the sine of the displacement angle (\\psi). The absolute value of the reactive power is equal to the non-active power. The ISO (and SI) unit for reactive power is the voltampere. The special name var and symbol \\textit{var are given in IEC 60027 1."@en .
+
+brick:Real_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Real Power" ;
+    owl:sameAs qudtqk:ActivePower,
+        brick:Active_Power ;
+    skos:broader brick:Electric_Power ;
+    skos:definition "(Active Power) is, under periodic conditions, the mean value, taken over one period (T), of the instantaneous power (p). In complex notation, (P = Re \\; S), where (S) is (complex power)\"."@en .
+
+brick:Rest_Room a owl:Class ;
+    rdfs:label "Rest Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Rest ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    owl:equivalentClass brick:Restroom ;
+    skos:definition "A room that provides toilets and washbowls. Alternate spelling of Restroom"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Rest,
+        tag:Room,
+        tag:Space .
+
+brick:Restroom a owl:Class ;
+    rdfs:label "Restroom" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Restroom ;
+                        owl:onProperty brick:hasTag ] _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    owl:equivalentClass brick:Rest_Room ;
+    skos:definition "A room that provides toilets and washbowls."@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Restroom,
+        tag:Room,
+        tag:Space .
+
+brick:Return_Hot_Water a owl:Class,
+        brick:Return_Hot_Water ;
+    rdfs:label "Return Hot Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot _:has_Return ) ],
+        brick:Hot_Water,
+        brick:Return_Water ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Hot,
+        tag:Liquid,
+        tag:Return,
+        tag:Water .
+
+brick:Return_Water_Flow_Sensor a owl:Class ;
+    rdfs:label "Return Water Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Return ) ],
+        brick:Water_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Flow,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Water .
+
+brick:Rooftop_Unit a owl:Class ;
+    rdfs:label "Rooftop Unit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Rooftop _:has_AHU ) ],
+        brick:AHU ;
+    owl:equivalentClass brick:RTU ;
+    skos:definition "Packaged air conditioner mounted on a roof, the conditioned air being discharged directly into the rooms below or through a duct system."@en ;
+    brick:hasAssociatedTag tag:AHU,
+        tag:Equipment,
+        tag:Rooftop .
+
+brick:Run_Status a owl:Class ;
+    rdfs:label "Run Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Status ) ],
+        brick:Start_Stop_Status ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Run,
+        tag:Status .
+
+brick:Run_Time_Sensor a owl:Class ;
+    rdfs:label "Run Time Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Run _:has_Time _:has_Sensor ) ],
+        brick:Duration_Sensor ;
+    skos:definition "Measures the duration for which a device was in an active or \"on\" state"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Run,
+        tag:Sensor,
+        tag:Time .
+
+brick:Security_Service_Room a owl:Class ;
+    rdfs:label "Security Service Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Security _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A class of spaces used by the security staff of a facility"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Security,
+        tag:Service,
+        tag:Space .
+
+brick:Smoke_Alarm a owl:Class ;
+    rdfs:label "Smoke Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Smoke _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with smoke."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
+        tag:Smoke .
+
+brick:Smoke_Detection_Alarm a owl:Class ;
+    rdfs:label "Smoke Detection Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Smoke _:has_Detection _:has_Alarm ) ],
+        brick:Smoke_Alarm ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Detection,
+        tag:Point,
+        tag:Smoke .
+
+brick:Solar_Radiance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Solar Radiance",
+        "Solar_Radiance" ;
+    qudt:applicableUnit unit:W-PER-M2-SR ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Radiance,
+        brick:Radiance ;
+    skos:definition "The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction",
+        "The amount of light that passes through or is emitted from the sun and falls within a given solid angle in a specified direction"@en .
+
+brick:Standby_Load_Shed_Command a owl:Class ;
+    rdfs:label "Standby Load Shed Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Standby _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Standby .
+
+brick:Standby_Unit_On_Off_Status a owl:Class ;
+    rdfs:label "Standby Unit On Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Standby _:has_Unit _:has_On _:has_Off _:has_Status ) ],
+        brick:On_Off_Status ;
+    skos:definition "Indicates the on/off status of a standby unit"@en ;
+    brick:hasAssociatedTag tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Standby,
+        tag:Status,
+        tag:Unit .
+
+brick:Static_Pressure_Step_Parameter a owl:Class ;
+    rdfs:label "Static Pressure Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Step _:has_Parameter ) ],
+        brick:Step_Parameter ;
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Static,
+        tag:Step .
+
+brick:Steam a owl:Class,
+        brick:Steam ;
+    rdfs:label "Steam" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Steam ) ],
+        brick:Gas ;
+    skos:definition "water in the vapor phase."@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Gas,
+        tag:Steam .
+
+brick:Steam_Radiator a owl:Class ;
+    rdfs:label "Steam Radiator" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Radiator _:has_Steam ) ],
+        brick:Radiator ;
+    skos:definition "Radiator that uses steam"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Radiator,
+        tag:Steam .
+
+brick:Storey a owl:Class ;
+    rdfs:label "Storey" ;
+    rdfs:subClassOf [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue tag:Storey ;
+                        owl:onProperty brick:hasTag ] _:has_Location ) ],
+        brick:Location ;
+    owl:equivalentClass brick:Floor ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Storey .
+
+brick:Supply_Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Supply Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Supply ) ],
+        brick:Air_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Air ;
+                        owl:onProperty brick:measures ] ) ],
+        brick:Discharge_Air_Flow_Sensor ;
+    skos:definition "Measures the rate of flow of supply air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply .
+
+brick:Supply_Air_Static_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Static Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+        brick:Static_Pressure_Setpoint ;
+    owl:equivalentClass brick:Discharge_Air_Static_Pressure_Setpoint ;
+    skos:definition "Sets static pressure of supply air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static,
+        tag:Supply .
+
+brick:Supply_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Supply Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Supply ) ],
+        brick:Air_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Air ;
+                        owl:onProperty brick:measures ] ) ],
+        brick:Discharge_Air_Temperature_Sensor ;
+    skos:definition "Measures the temperature of supply air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Switch a owl:Class ;
+    rdfs:label "Switch" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface _:has_Switch ) ],
+        brick:Interface ;
+    skos:definition "A switch used to operate all or part of a lighting installation"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Interface,
+        tag:Switch .
+
+brick:TVOC_Concentration a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "TVOC Concentration",
+        "TVOCConcentration" ;
+    qudt:applicableUnit unit:PPM ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Dimensionless,
+        brick:Air_Quality ;
+    skos:definition "The concentration of total volatile organic compounds in air" .
+
+brick:TVOC_Sensor a owl:Class ;
+    rdfs:label "TVOC Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Particulate _:has_Matter _:has_TVOC ) ],
+        brick:Particulate_Matter_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:TVOC_Concentration ;
+                        owl:onProperty brick:measures ] ) ] ;
+    brick:hasAssociatedTag tag:Matter,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor,
+        tag:TVOC .
+
+brick:Temperature_Step_Parameter a owl:Class ;
+    rdfs:label "Temperature Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Step _:has_Parameter ) ],
+        brick:Step_Parameter,
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
+        tag:Step,
+        tag:Temperature .
+
+brick:Thermal_Power_Sensor a owl:Class ;
+    rdfs:label "Thermal Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power _:has_Thermal ) ],
+        brick:Power_Sensor ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Power,
+        tag:Sensor,
+        tag:Thermal .
+
+brick:Torque a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Torque" ;
+    qudt:applicableUnit unit:N-M ;
+    owl:sameAs qudtqk:Torque ;
+    skos:definition "In physics, a torque (τ) is a vector that measures the tendency of a force to rotate an object about some axis. The magnitude of a torque is defined as force times its lever arm. Just as a force is a push or a pull, a torque can be thought of as a twist. The SI unit for torque is newton meters ((N m)). In U.S. customary units, it is measured in foot pounds (ft lbf) (also known as \"pounds feet\"). Mathematically, the torque on a particle (which has the position r in some reference frame) can be defined as the cross product: (τ = r x F) where, r is the particle's position vector relative to the fulcrum  F is the force acting on the particles,  or, more generally, torque can be defined as the rate of change of angular momentum: (τ = dL/dt) where, L is the angular momentum vector  t stands for time."@en .
+
+brick:Torque_Sensor a owl:Class ;
+    rdfs:label "Torque Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Torque ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Torque ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures torque, the tendency of a force to rotate an object about some axis"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
+        tag:Torque .
+
+brick:Unoccupied_Load_Shed_Command a owl:Class ;
+    rdfs:label "Unoccupied Load Shed Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Load_Shed_Command ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Unoccupied .
+
+brick:VAV a owl:Class ;
+    rdfs:label "VAV" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:VAV ;
+                        owl:onProperty brick:hasTag ] ) ],
+        brick:Terminal_Unit ;
+    skos:definition "See Variable_Air_Volume_Box"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:VAV .
+
+brick:VolumeShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:in ( unit:FT3 unit:M3 ) ;
+            sh:minCount 1 ;
+            sh:path brick:hasUnit ],
+        [ a sh:PropertyShape ;
+            sh:datatype xsd:float ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:Water_Level_Alarm a owl:Class ;
+    rdfs:label "Water Level Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Level _:has_Alarm _:has_Point ) ],
+        brick:Water_Alarm ;
+    skos:definition "An alarm that indicates a high or low water level e.g. in a basin"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Level,
+        tag:Point,
+        tag:Water .
+
+brick:Water_Usage_Sensor a owl:Class ;
+    rdfs:label "Water Usage Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage _:has_Water ) ],
+        brick:Usage_Sensor ;
+    skos:definition "Measures the amount of water that is consumed, over some period of time"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
+        tag:Usage,
+        tag:Water .
+
+brick:Wind_Direction a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Wind Direction",
+        "Wind_Direction" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader brick:Direction ;
+    skos:definition "Direction of wind relative to North",
+        "Direction of wind relative to North"@en .
+
+brick:Wind_Speed a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Wind Speed",
+        "Wind_Speed" ;
+    qudt:applicableUnit unit:FT-PER-HR,
+        unit:FT-PER-SEC,
+        unit:KiloM-PER-HR,
+        unit:KiloM-PER-SEC,
+        unit:M-PER-HR,
+        unit:M-PER-SEC,
+        unit:MI-PER-HR,
+        unit:MI-PER-SEC ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T-1D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Speed,
+        brick:Speed ;
+    skos:definition "Measured speed of wind, caused by air moving from high to low pressure",
+        "Measured speed of wind, caused by air moving from high to low pressure"@en .
+
+brick:YearBuiltShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:datatype xsd:integer ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:controls a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    owl:inverseOf brick:isControlledBy .
+
+brick:hasAssociatedTag a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain owl:Class ;
+    rdfs:range brick:Tag ;
+    owl:inverseOf brick:isAssociatedWith ;
+    skos:definition "The class is associated with the given tag"@en .
+
+brick:hasLocation a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:range brick:Location ;
+    owl:inverseOf brick:isLocationOf ;
+    skos:definition "Subject is physically located in the location given by the object"@en .
+
+brick:hasPart a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    owl:inverseOf brick:isPartOf ;
+    skos:definition "The subject is composed in part of the entity given by the object"@en .
+
+brick:hasPoint a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:range brick:Point ;
+    owl:inverseOf brick:isPointOf ;
+    skos:definition "The subject has a digital/analog input/output point given by the object"@en .
+
+brick:hasTimeseriesId a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:TimeseriesReference ;
+    rdfs:range xsd:string ;
+    skos:definition "The unique identifier (primary key) for this TimeseriesReference in some database"@en .
+
+brick:isAssociatedWith a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Tag ;
+    rdfs:range owl:Class ;
+    owl:inverseOf brick:hasAssociatedTag ;
+    skos:definition "The tag is associated with the given class"@en .
+
+brick:isControlledBy a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    owl:inverseOf brick:controls .
+
+brick:isFedBy a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    owl:inverseOf brick:feeds .
+
+brick:isLocationOf a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Location ;
+    owl:inverseOf brick:hasLocation ;
+    skos:definition "Subject is the physical location encapsulating the object"@en .
+
+brick:isMeasuredBy a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Measurable ;
+    rdfs:range brick:Point .
+
+brick:isPartOf a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    owl:inverseOf brick:hasPart .
+
+brick:isPointOf a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Point ;
+    owl:inverseOf brick:hasPoint .
+
+brick:isRegulatedBy a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Substance ;
+    rdfs:range brick:Equipment .
+
+brick:isTagOf a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Tag .
+
+brick:storedAt a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:TimeseriesReference ;
+    skos:definition "A reference to where the data for this TimeseriesReference is stored"@en .
+
+unit:GRAIN qudt:symbol "gr" .
+
+unit:GigaHZ qudt:symbol "GHz" .
+
+unit:HZ qudt:symbol "Hz" .
+
+unit:KiloHZ qudt:symbol "KHz" .
+
+unit:MegaHZ qudt:symbol "MHz" .
+
+brick:Active_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Active Power" ;
+    owl:sameAs qudtqk:ActivePower,
+        brick:Real_Power ;
+    skos:broader brick:Electric_Power ;
+    skos:definition "(Active Power) is, under periodic conditions, the mean value, taken over one period (T), of the instantaneous power (p). In complex notation, (P = Re \\; S), where (S) is (complex power)\"."@en .
+
+brick:Air_Enthalpy_Sensor a owl:Class ;
+    rdfs:label "Air Enthalpy Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Enthalpy _:has_Sensor ) ],
+        brick:Enthalpy_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Enthalpy ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the total heat content of air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Enthalpy,
+        tag:Point,
+        tag:Sensor .
+
+brick:Air_Flow_Demand_Setpoint a owl:Class ;
+    rdfs:label "Air Flow Demand Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Demand _:has_Setpoint ) ],
+        brick:Air_Flow_Setpoint,
+        brick:Demand_Setpoint ;
+    skos:definition "Sets the rate of air flow required for a process"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Demand,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Limit,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Air_Grains_Sensor a owl:Class ;
+    rdfs:label "Air Grains Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Air _:has_Grains ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Grains ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the mass of water vapor in air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Grains,
+        tag:Point,
+        tag:Sensor .
+
+brick:Air_Temperature_Step_Parameter a owl:Class ;
+    rdfs:label "Air Temperature Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Step _:has_Parameter ) ],
+        brick:Temperature_Step_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Parameter,
+        tag:Point,
+        tag:Step,
+        tag:Temperature .
+
+brick:Angle_Sensor a owl:Class ;
+    rdfs:label "Angle Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Angle _:has_Sensor ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Angle ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measues the planar angle of some phenomenon"@en ;
+    brick:hasAssociatedTag tag:Angle,
+        tag:Point,
+        tag:Sensor .
+
+brick:Building_Air a owl:Class,
+        brick:Building_Air ;
+    rdfs:label "Building Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Building ) ],
+        brick:Air ;
+    skos:definition "air contained within a building"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Building,
+        tag:Fluid,
+        tag:Gas .
+
+brick:Bypass_Air a owl:Class,
+        brick:Bypass_Air ;
+    rdfs:label "Bypass Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Bypass ) ],
+        brick:Air ;
+    skos:definition "air in a bypass duct, used to relieve static pressure"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Bypass,
+        tag:Fluid,
+        tag:Gas .
+
+brick:Bypass_Valve a owl:Class ;
+    rdfs:label "Bypass Valve" ;
+    rdfs:seeAlso <https://www.petropedia.com/definition/5050/bypass-valve> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Bypass _:has_Valve _:has_Equipment ) ],
+        brick:Valve ;
+    skos:definition "A type of valve installed in a bypass pipeline"@en ;
+    brick:hasAssociatedTag tag:Bypass,
+        tag:Equipment,
+        tag:Valve .
+
+brick:CRAC a owl:Class ;
+    rdfs:label "CRAC" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_CRAC ) ],
+        brick:HVAC_Equipment ;
+    owl:equivalentClass brick:Computer_Room_Air_Conditioning ;
+    brick:hasAssociatedTag tag:CRAC,
+        tag:Equipment .
+
+brick:Chilled_Water_Differential_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Chilled Water Differential Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Chilled _:has_Water _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+        brick:Differential_Pressure_Setpoint ;
+    skos:definition "Sets differential pressure of chilled water"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Water .
+
+brick:Coil a owl:Class ;
+    rdfs:label "Coil" ;
+    rdfs:seeAlso <ASHRAE> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Coil ) ],
+        brick:Heat_Exchanger ;
+    skos:definition "Cooling or heating element made of pipe or tube that may or may not be finned and formed into helical or serpentine shape"@en ;
+    brick:hasAssociatedTag tag:Coil,
+        tag:Equipment .
+
+brick:Condenser_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Condenser Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Condenser _:has_Water _:has_Temperature _:has_Sensor _:has_Point ) ],
+        brick:Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Condenser_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of condenser water"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Conductivity a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Conductivity" ;
+    owl:sameAs qudtqk:Conductivity .
+
+brick:Current_Output_Sensor a owl:Class ;
+    rdfs:label "Current Output Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Current _:has_Output _:has_Sensor ) ],
+        brick:Current_Sensor ;
+    skos:definition "Senses the amperes of electrical current produced as output by a device"@en ;
+    brick:hasAssociatedTag tag:Current,
+        tag:Output,
+        tag:Point,
+        tag:Sensor .
+
+brick:Direction a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Direction" .
+
+brick:Discharge_Air_Flow_Reset_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Flow Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    skos:definition "Setpoints used in Reset strategies"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint .
+
+brick:Discharge_Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Discharge Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air _:has_Discharge ) ],
+        brick:Air_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Discharge_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor .
+
+brick:Discharge_Air_Static_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Static Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Static _:has_Pressure _:has_Setpoint ) ],
+        brick:Static_Pressure_Setpoint ;
+    skos:definition "Sets static pressure of discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Discharge_Air_Temperature_Alarm a owl:Class ;
+    rdfs:label "Discharge Air Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Alarm ) ],
+        brick:Air_Temperature_Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with the temperature of discharge air."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Discharge,
+        tag:Point,
+        tag:Temperature .
+
+brick:Discharge_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Discharge Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Discharge ) ],
+        brick:Air_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Discharge_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Discharge_Air_Temperature_Setpoint_Limit a owl:Class ;
+    rdfs:label "Discharge Air Temperature Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Limit _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Discharge_Air_Temperature_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Limit,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Discharge_Hot_Water a owl:Class,
+        brick:Discharge_Hot_Water ;
+    rdfs:label "Discharge Hot Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot _:has_Discharge ) ],
+        brick:Discharge_Water,
+        brick:Hot_Water ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Fluid,
+        tag:Hot,
+        tag:Liquid,
+        tag:Water .
+
+brick:Discharge_Water_Flow_Sensor a owl:Class ;
+    rdfs:label "Discharge Water Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Discharge ) ],
+        brick:Water_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Discharge_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of discharge water"@en ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor,
+        tag:Water .
+
+brick:Distribution_Frame a owl:Class ;
+    rdfs:label "Distribution Frame" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Distribution _:has_Frame _:has_Telecom _:has_Room _:has_Space _:has_Location ) ],
+        brick:Telecom_Room ;
+    skos:definition "A class of spaces where the cables carrying signals meet and connect, e.g. a wiring closet or a broadcast downlink room"@en ;
+    brick:hasAssociatedTag tag:Distribution,
+        tag:Frame,
+        tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:Telecom .
+
+brick:Electric_Energy a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Electric Energy",
+        "ElectricEnergy" ;
+    qudt:applicableUnit unit:J ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L2I0M1H0T-2D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Energy,
+        brick:Energy ;
+    skos:definition "A form of energy resulting from the flow of electrical charge" .
+
+brick:Emergency_Power_Off_System_Status a owl:Class ;
+    rdfs:label "Emergency Power Off System Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Emergency _:has_Power _:has_Off _:has_System _:has_Status ) ],
+        brick:Off_Status,
+        brick:System_Status ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Off,
+        tag:Point,
+        tag:Power,
+        tag:Status,
+        tag:System .
+
+brick:Entering_Water a owl:Class,
+        brick:Entering_Water ;
+    rdfs:label "Entering Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Entering ) ],
+        brick:Water ;
+    brick:hasAssociatedTag tag:Entering,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+brick:Exhaust_Air_Static_Pressure_Sensor a owl:Class ;
+    rdfs:label "Exhaust Air Static Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static _:has_Air _:has_Exhaust ) ],
+        brick:Static_Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Static_Pressure ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Exhaust_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "The static pressure of air within exhaust regions of an HVAC system"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Static .
+
+brick:Fault_Status a owl:Class ;
+    rdfs:label "Fault Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Fault _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates the presence of a fault in a device, system or control loop"@en ;
+    brick:hasAssociatedTag tag:Fault,
+        tag:Point,
+        tag:Status .
+
+brick:Flow_Sensor a owl:Class ;
+    rdfs:label "Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of some substance"@en ;
+    brick:hasAssociatedTag tag:Flow,
+        tag:Point,
+        tag:Sensor .
+
+brick:Frequency a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Frequency" ;
+    qudt:applicableUnit unit:GigaHZ,
+        unit:HZ,
+        unit:KiloHZ,
+        unit:MegaHZ ;
+    owl:sameAs qudtqk:Frequency ;
+    skos:definition "Frequency is the number of occurrences of a repeating event per unit time. The repetition of the events may be periodic (that is. the length of time between event repetitions is fixed) or aperiodic (i.e. the length of time between event repetitions varies). Therefore, we distinguish between periodic and aperiodic frequencies. In the SI system, periodic frequency is measured in hertz (Hz) or multiples of hertz, while aperiodic frequency is measured in becquerel (Bq).  In spectroscopy, ( u) is mostly used. Light passing through different media keeps its frequency, but not its wavelength or wavenumber."@en .
+
+brick:Frost a owl:Class,
+        brick:Frost ;
+    rdfs:label "Frost" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Frost ) ],
+        brick:Solid ;
+    skos:definition "frost formed on the cold surface (tubes, plates) of a cooling coil."@en ;
+    brick:hasAssociatedTag tag:Frost,
+        tag:Solid .
+
+brick:Hail a owl:Class,
+        brick:Hail ;
+    rdfs:label "Hail" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Solid _:has_Hail ) ],
+        brick:Solid ;
+    skos:definition "pellets of frozen rain which fall in showers from cumulonimbus clouds."@en ;
+    brick:hasAssociatedTag tag:Hail,
+        tag:Solid .
+
+brick:Heating_Discharge_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Heating Discharge Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Heat _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets discharge air flow for heating"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Heat,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Heating_Ventilation_Air_Conditioning_System a owl:Class ;
+    rdfs:label "Heating Ventilation Air Conditioning System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Heat _:has_Ventilation _:has_Air _:has_Conditioning _:has_System ) ],
+        brick:System ;
+    owl:equivalentClass brick:HVAC_System ;
+    skos:definition "The equipment, distribution systems and terminals that provide, either collectively or individually, the processes of heating, ventilating or air conditioning to a building or portion of a building"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Conditioning,
+        tag:Heat,
+        tag:System,
+        tag:Ventilation .
+
+brick:High_Temperature_Alarm a owl:Class ;
+    rdfs:label "High Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_High _:has_Temperature _:has_Alarm ) ],
+        brick:Temperature_Alarm ;
+    skos:definition "An alarm that indicates high temperature."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:High,
+        tag:Point,
+        tag:Temperature .
+
+brick:Hot_Water_Return_Temperature_Sensor a owl:Class ;
+    rdfs:label "Hot Water Return Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Return _:has_Temperature _:has_Sensor ) ],
+        brick:Return_Water_Temperature_Sensor ;
+    skos:definition "Measures the temperature of water returned to a hot water system"@en ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Hot_Water_Supply_Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Hot Water Supply Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_High_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:High,
+        tag:Hot,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Hot_Water_Supply_Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Hot Water Supply Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Hot _:has_Water _:has_Supply _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Low_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Hot_Water_Valve a owl:Class ;
+    rdfs:label "Hot Water Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Hot _:has_Valve _:has_Water _:has_Equipment ) ],
+        brick:Heating_Valve,
+        brick:Water_Valve ;
+    skos:definition "A valve regulating the flow of hot water"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Hot,
+        tag:Valve,
+        tag:Water .
+
+brick:Humidity_Alarm a owl:Class ;
+    rdfs:label "Humidity Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with the concentration of water vapor in the air."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Humidity,
+        tag:Point .
+
+brick:Intercom_Equipment a owl:Class ;
+    rdfs:label "Intercom Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Security _:has_Intercom ) ],
+        brick:Security_Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Intercom,
+        tag:Security .
+
+brick:Interface a owl:Class ;
+    rdfs:label "Interface" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Interface ) ],
+        brick:Lighting_Equipment ;
+    skos:definition "A device that provides an occupant control over a lighting system"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Interface .
+
+brick:Leaving_Water a owl:Class,
+        brick:Leaving_Water ;
+    rdfs:label "Leaving Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Leaving ) ],
+        brick:Water ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Leaving,
+        tag:Liquid,
+        tag:Water .
+
+brick:Lighting a owl:Class ;
+    rdfs:label "Lighting" ;
+    rdfs:subClassOf brick:Lighting_Equipment .
+
+brick:Lighting_Equipment a owl:Class ;
+    rdfs:label "Lighting Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lighting _:has_Equipment ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Lighting .
+
+brick:Load_Shed_Command a owl:Class ;
+    rdfs:label "Load Shed Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Shed _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls load shedding behavior provided by a control system"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Load,
+        tag:Point,
+        tag:Shed .
+
+brick:Lobby a owl:Class ;
+    rdfs:label "Lobby" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Lobby _:has_Common _:has_Space _:has_Location ) ],
+        brick:Common_Space ;
+    skos:definition "A space just after the entrance to a building or other space of a building, where visitors can wait"@en ;
+    brick:hasAssociatedTag tag:Common,
+        tag:Lobby,
+        tag:Location,
+        tag:Space .
+
+brick:Max_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Cooling Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Cool _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Cooling_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Flow,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Max_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Heating Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Heat _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Heating_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Max_Static_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Static Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Limit,
+        brick:Static_Pressure_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Static_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Min_Cooling_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Cooling Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Cool _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Cooling_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Flow,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Min_Heating_Supply_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Heating Supply Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Heat _:has_Supply _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Air_Flow_Setpoint_Limit ;
+    owl:equivalentClass brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Heating_Supply_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Min_Static_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Static Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Limit,
+        brick:Static_Pressure_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Static_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Mode_Status a owl:Class ;
+    rdfs:label "Mode Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mode _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates which mode a system, device or control loop is currently in"@en ;
+    brick:hasAssociatedTag tag:Mode,
+        tag:Point,
+        tag:Status .
+
+brick:Motor a owl:Class ;
+    rdfs:label "Motor" ;
+    rdfs:seeAlso <https://xp20.ashrae.org/terminology/index.php?term=motor> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Motor ) ],
+        brick:Equipment ;
+    skos:definition "A machine in which power is applied to do work by the conversion of various forms of energy into mechanical force and motion."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Motor .
+
+brick:Occupied_Supply_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Occupied Supply Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Supply_Air_Flow_Setpoint ;
+    owl:equivalentClass brick:Occupied_Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets supply air flow rate when occupied"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Oil a owl:Class,
+        brick:Oil ;
+    rdfs:label "Oil" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Oil ) ],
+        brick:Liquid ;
+    skos:definition "a viscous liquid derived from petroleum, especially for use as a fuel or lubricant."@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Oil .
+
+brick:On_Status a owl:Class ;
+    rdfs:label "On Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if a control loop, relay or equipment is on"@en ;
+    brick:hasAssociatedTag tag:On,
+        tag:Point,
+        tag:Status .
+
+brick:Outside_Air_Lockout_Temperature_Differential_Parameter a owl:Class ;
+    rdfs:label "Outside Air Lockout Temperature Differential Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Lockout _:has_Temperature _:has_Differential _:has_Parameter ) ],
+        brick:Lockout_Temperature_Differential_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Lockout,
+        tag:Outside,
+        tag:Parameter,
+        tag:Point,
+        tag:Temperature .
+
+brick:Overridden_Status a owl:Class ;
+    rdfs:label "Overridden Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Overridden _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if the expected operating status of an equipment or control loop has been overridden"@en ;
+    brick:hasAssociatedTag tag:Overridden,
+        tag:Point,
+        tag:Status .
+
+brick:Phasor a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Phasor" .
+
+brick:Phasor_Angle a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Phasor Angle",
+        "PhasorAngle" ;
+    qudt:applicableUnit unit:ARCMIN,
+        unit:ARCSEC,
+        unit:DEG,
+        unit:GON,
+        unit:GRAD,
+        unit:MIL,
+        unit:MicroRAD,
+        unit:MilliARCSEC,
+        unit:MilliRAD,
+        unit:RAD,
+        unit:REV ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H0T0D1> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:PlaneAngle ;
+    skos:definition "Angle component of a phasor" ;
+    skos:related brick:Phasor .
+
+brick:Position_Limit a owl:Class ;
+    rdfs:label "Position Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Limit ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Position_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Point,
+        tag:Position .
+
+brick:Power_Sensor a owl:Class ;
+    rdfs:label "Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Power ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the amount of instantaneous power consumed"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Power,
+        tag:Sensor .
+
+brick:Pressure_Alarm a owl:Class ;
+    rdfs:label "Pressure Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pressure _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with pressure."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
+        tag:Pressure .
+
+brick:Return_Air_Temperature_Alarm a owl:Class ;
+    rdfs:label "Return Air Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Temperature _:has_Alarm ) ],
+        brick:Air_Temperature_Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with the temperature of return air."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Point,
+        tag:Return,
+        tag:Temperature .
+
+brick:Speed a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Speed" ;
+    owl:sameAs qudtqk:Speed .
+
+brick:Speed_Setpoint a owl:Class ;
+    rdfs:label "Speed Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets speed"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
+        tag:Speed .
+
+brick:Speed_Setpoint_Limit a owl:Class ;
+    rdfs:label "Speed Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Speed _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Speed_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint,
+        tag:Speed .
+
+brick:StageShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:in ( 1 2 3 4 ) ;
+            sh:minCount 1 ;
+            sh:path brick:value ] .
+
+brick:Static_Pressure_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Static Pressure Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+        brick:Deadband_Setpoint,
+        brick:Static_Pressure_Setpoint ;
+    skos:definition "Sets the size of a deadband of static pressure"@en ;
+    brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Static_Pressure_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Static Pressure Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Static,
+        tag:Time .
+
+brick:Storage_Room a owl:Class ;
+    rdfs:label "Storage Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Storage _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A class of spaces used for storage"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:Storage .
+
+brick:Supply_Air_Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint,
+        brick:Temperature_Deadband_Setpoint ;
+    owl:equivalentClass brick:Discharge_Air_Temperature_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature of supply air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Deadband,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Supply_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Supply Air Temperature Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Proportional_Band_Parameter,
+        brick:Temperature_Parameter ;
+    owl:equivalentClass brick:Discharge_Air_Temperature_Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Supply_Hot_Water a owl:Class,
+        brick:Supply_Hot_Water ;
+    rdfs:label "Supply Hot Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot _:has_Supply ) ],
+        brick:Hot_Water,
+        brick:Supply_Water ;
+    owl:equivalentClass brick:Discharge_Hot_Water ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Hot,
+        tag:Liquid,
+        tag:Supply,
+        tag:Water .
+
+brick:Supply_Water_Flow_Sensor a owl:Class ;
+    rdfs:label "Supply Water Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water _:has_Supply ) ],
+        brick:Water_Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Water ;
+                        owl:onProperty brick:measures ] ) ],
+        brick:Discharge_Water_Flow_Sensor ;
+    skos:definition "Measures the rate of flow of hot supply water"@en ;
+    brick:hasAssociatedTag tag:Flow,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Water .
+
+brick:System_Enable_Command a owl:Class ;
+    rdfs:label "System Enable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command _:has_System ) ],
+        brick:Enable_Command ;
+    skos:definition "Enables operation of a system"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Enable,
+        tag:Point,
+        tag:System .
+
+brick:Temperature_Differential_Reset_Setpoint a owl:Class ;
+    rdfs:label "Temperature Differential Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:ThermalTransmittenceShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:datatype xsd:float ;
+            sh:minCount 1 ;
+            sh:path brick:value ],
+        [ a sh:PropertyShape ;
+            sh:in ( unit:BTU_IT unit:W-PER-M2-K ) ;
+            sh:minCount 1 ;
+            sh:path brick:hasUnit ] .
+
+brick:Time a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Time" ;
+    qudt:applicableUnit unit:DAY,
+        unit:DAY_Sidereal,
+        unit:HR,
+        unit:HR_Sidereal,
+        unit:KiloSEC,
+        unit:MIN,
+        unit:MIN_Sidereal,
+        unit:MO,
+        unit:MicroSEC,
+        unit:MilliSEC,
+        unit:NanoSEC,
+        unit:PlanckTime,
+        unit:SEC,
+        unit:SH,
+        unit:WK,
+        unit:YR,
+        unit:YR_Sidereal,
+        unit:YR_TROPICAL ;
+    owl:sameAs qudtqk:Time .
+
+brick:Time_Parameter a owl:Class ;
+    rdfs:label "Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Time ) ],
+        brick:PID_Parameter ;
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
+        tag:Time .
+
+brick:Time_Setpoint a owl:Class ;
+    rdfs:label "Time Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Time _:has_Setpoint ) ],
+        brick:Setpoint ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
+        tag:Time .
+
+brick:Tolerance_Parameter a owl:Class ;
+    rdfs:label "Tolerance Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Tolerance _:has_Parameter ) ],
+        brick:Parameter ;
+    skos:definition "difference between upper and lower limits of size for a given nominal dimension or value."@en ;
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
+        tag:Tolerance .
+
+brick:Variable_Air_Volume_Box a owl:Class ;
+    rdfs:label "Variable Air Volume Box" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Variable_air_volume> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Variable _:has_Volume _:has_Box ) ],
+        brick:Terminal_Unit ;
+    owl:equivalentClass brick:VAV ;
+    skos:definition "A device that regulates the volume and temperature of air delivered to a zone by opening or closing a damper"@en ;
+    brick:hasAssociatedTag tag:Box,
+        tag:Equipment,
+        tag:Variable,
+        tag:Volume .
+
+brick:Water_Heater a owl:Class ;
+    rdfs:label "Water Heater" ;
+    rdfs:seeAlso <https://www.merriam-webster.com/dictionary/waterheater> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Heater _:has_Equipment ) ],
+        brick:Equipment ;
+    skos:definition "An apparatus for heating and usually storing hot water"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heater,
+        tag:Water .
+
+brick:Water_Level_Sensor a owl:Class ;
+    rdfs:label "Water Level Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Water _:has_Level ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Level ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the height/level of water in some container"@en ;
+    brick:hasAssociatedTag tag:Level,
+        tag:Point,
+        tag:Sensor,
+        tag:Water .
+
+brick:Water_Temperature_Alarm a owl:Class ;
+    rdfs:label "Water Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Temperature _:has_Alarm ) ],
+        brick:Temperature_Alarm,
+        brick:Water_Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with temperature of water."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
+        tag:Temperature,
+        tag:Water .
+
+brick:Wet_Bulb_Temperature a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Wet Bulb Temperature",
+        "Wet_Bulb_Temperature" ;
+    qudt:applicableUnit unit:DEG_C,
+        unit:DEG_F,
+        unit:K ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L0I0M0H1T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:ThermodynamicTemperature,
+        brick:Temperature ;
+    skos:definition "The temperature read by a thermometer covered in water-soaked cloth (wet-bulb thermometer) over which air is passed. A wet-bulb thermometer indicates a temperature close to the true (thermodynamic) wet-bulb temperature. The wet-bulb temperature is the lowest temperature that can be reached under current ambient conditions by the evaporation of water only.  DBT is the temperature that is usually thought of as air temperature, and it is the true thermodynamic temperature. It indicates the amount of heat in the air and is directly proportional to the mean kinetic energy of the air molecule. (https://en.wikipedia.org/wiki/Wet-bulb_temperature)",
+        "The temperature read by a thermometer covered in water-soaked cloth (wet-bulb thermometer) over which air is passed. A wet-bulb thermometer indicates a temperature close to the true (thermodynamic) wet-bulb temperature. The wet-bulb temperature is the lowest temperature that can be reached under current ambient conditions by the evaporation of water only.  DBT is the temperature that is usually thought of as air temperature, and it is the true thermodynamic temperature. It indicates the amount of heat in the air and is directly proportional to the mean kinetic energy of the air molecule. (https://en.wikipedia.org/wiki/Wet-bulb_temperature)"@en .
+
+brick:feeds a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    owl:inverseOf brick:isFedBy ;
+    skos:definition "The subject is upstream of the object in the context of some sequential process; some media is passed between them"@en .
+
+tag:Ablutions a brick:Tag ;
+    rdfs:label "Ablutions" .
+
+tag:Absorption a brick:Tag ;
+    rdfs:label "Absorption" .
+
+tag:Acceleration a brick:Tag ;
+    rdfs:label "Acceleration" .
+
+tag:Auditorium a brick:Tag ;
+    rdfs:label "Auditorium" .
+
+tag:Auto a brick:Tag ;
+    rdfs:label "Auto" .
+
+tag:Automatic a brick:Tag ;
+    rdfs:label "Automatic" .
+
+tag:Azimuth a brick:Tag ;
+    rdfs:label "Azimuth" .
+
+tag:Basement a brick:Tag ;
+    rdfs:label "Basement" .
+
+tag:Bench a brick:Tag ;
+    rdfs:label "Bench" .
+
+tag:Blowdown a brick:Tag ;
+    rdfs:label "Blowdown" .
+
+tag:Boiler a brick:Tag ;
+    rdfs:label "Boiler" .
+
+tag:Booster a brick:Tag ;
+    rdfs:label "Booster" .
+
+tag:Booth a brick:Tag ;
+    rdfs:label "Booth" .
+
+tag:Break a brick:Tag ;
+    rdfs:label "Break" .
+
+tag:Breaker a brick:Tag ;
+    rdfs:label "Breaker" .
+
+tag:Breakroom a brick:Tag ;
+    rdfs:label "Breakroom" .
+
+tag:Broadcast a brick:Tag ;
+    rdfs:label "Broadcast" .
+
+tag:Bus a brick:Tag ;
+    rdfs:label "Bus" .
+
+tag:Button a brick:Tag ;
+    rdfs:label "Button" .
+
+tag:CAV a brick:Tag ;
+    rdfs:label "CAV" .
+
+tag:Cafeteria a brick:Tag ;
+    rdfs:label "Cafeteria" .
+
+tag:Capacity a brick:Tag ;
+    rdfs:label "Capacity" .
+
+tag:Ceiling a brick:Tag ;
+    rdfs:label "Ceiling" .
+
+tag:Center a brick:Tag ;
+    rdfs:label "Center" .
+
+tag:Centrifugal a brick:Tag ;
+    rdfs:label "Centrifugal" .
+
+tag:Change a brick:Tag ;
+    rdfs:label "Change" .
+
+tag:Close a brick:Tag ;
+    rdfs:label "Close" .
+
+tag:Code a brick:Tag ;
+    rdfs:label "Code" .
+
+tag:Cold a brick:Tag ;
+    rdfs:label "Cold" .
+
+tag:Coldest a brick:Tag ;
+    rdfs:label "Coldest" .
+
+tag:Communication a brick:Tag ;
+    rdfs:label "Communication" .
+
+tag:Compressor a brick:Tag ;
+    rdfs:label "Compressor" .
+
+tag:Computer a brick:Tag ;
+    rdfs:label "Computer" .
+
+tag:Concessions a brick:Tag ;
+    rdfs:label "Concessions" .
+
+tag:Condensate a brick:Tag ;
+    rdfs:label "Condensate" .
+
+tag:Conference a brick:Tag ;
+    rdfs:label "Conference" .
+
+tag:Constant a brick:Tag ;
+    rdfs:label "Constant" .
+
+tag:Contact a brick:Tag ;
+    rdfs:label "Contact" .
+
+tag:Copy a brick:Tag ;
+    rdfs:label "Copy" .
+
+tag:Cubicle a brick:Tag ;
+    rdfs:label "Cubicle" .
+
+tag:Curtailment a brick:Tag ;
+    rdfs:label "Curtailment" .
+
+tag:Cutout a brick:Tag ;
+    rdfs:label "Cutout" .
+
+tag:Dc a brick:Tag ;
+    rdfs:label "Dc" .
+
+tag:Deceleration a brick:Tag ;
+    rdfs:label "Deceleration" .
+
+tag:Dehumidification a brick:Tag ;
+    rdfs:label "Dehumidification" .
+
+tag:Desk a brick:Tag ;
+    rdfs:label "Desk" .
+
+tag:Detention a brick:Tag ;
+    rdfs:label "Detention" .
+
+tag:Dimmer a brick:Tag ;
+    rdfs:label "Dimmer" .
+
+tag:Disconnect a brick:Tag ;
+    rdfs:label "Disconnect" .
+
+tag:Dock a brick:Tag ;
+    rdfs:label "Dock" .
+
+tag:Drench a brick:Tag ;
+    rdfs:label "Drench" .
+
+tag:Driver a brick:Tag ;
+    rdfs:label "Driver" .
+
+tag:Econcycle a brick:Tag ;
+    rdfs:label "Econcycle" .
+
+tag:Employee a brick:Tag ;
+    rdfs:label "Employee" .
+
+tag:Environment a brick:Tag ;
+    rdfs:label "Environment" .
+
+tag:Evaporative a brick:Tag ;
+    rdfs:label "Evaporative" .
+
+tag:Even a brick:Tag ;
+    rdfs:label "Even" .
+
+tag:Exercise a brick:Tag ;
+    rdfs:label "Exercise" .
+
+tag:Eye a brick:Tag ;
+    rdfs:label "Eye" .
+
+tag:FCU a brick:Tag ;
+    rdfs:label "FCU" .
+
+tag:Field a brick:Tag ;
+    rdfs:label "Field" .
+
+tag:Final a brick:Tag ;
+    rdfs:label "Final" .
+
+tag:First a brick:Tag ;
+    rdfs:label "First" .
+
+tag:FirstAid a brick:Tag ;
+    rdfs:label "FirstAid" .
+
+tag:Formaldehyde a brick:Tag ;
+    rdfs:label "Formaldehyde" .
+
+tag:Freezer a brick:Tag ;
+    rdfs:label "Freezer" .
+
+tag:Fuel a brick:Tag ;
+    rdfs:label "Fuel" .
+
+tag:Furniture a brick:Tag ;
+    rdfs:label "Furniture" .
+
+tag:Gasoline a brick:Tag ;
+    rdfs:label "Gasoline" .
+
+tag:Gatehouse a brick:Tag ;
+    rdfs:label "Gatehouse" .
+
+tag:Glycol a brick:Tag ;
+    rdfs:label "Glycol" .
+
+tag:Glycool a brick:Tag ;
+    rdfs:label "Glycool" .
+
+tag:HX a brick:Tag ;
+    rdfs:label "HX" .
+
+tag:Hallway a brick:Tag ;
+    rdfs:label "Hallway" .
+
+tag:Handler a brick:Tag ;
+    rdfs:label "Handler" .
+
+tag:Handling a brick:Tag ;
+    rdfs:label "Handling" .
+
+tag:Hazardous a brick:Tag ;
+    rdfs:label "Hazardous" .
+
+tag:Head a brick:Tag ;
+    rdfs:label "Head" .
+
+tag:Heating a brick:Tag ;
+    rdfs:label "Heating" .
+
+tag:Hold a brick:Tag ;
+    rdfs:label "Hold" .
+
+tag:Hose a brick:Tag ;
+    rdfs:label "Hose" .
+
+tag:Hospitality a brick:Tag ;
+    rdfs:label "Hospitality" .
+
+tag:Humidification a brick:Tag ;
+    rdfs:label "Humidification" .
+
+tag:Humidify a brick:Tag ;
+    rdfs:label "Humidify" .
+
+tag:IDF a brick:Tag ;
+    rdfs:label "IDF" .
+
+tag:Information a brick:Tag ;
+    rdfs:label "Information" .
+
+tag:Intrusion a brick:Tag ;
+    rdfs:label "Intrusion" .
+
+tag:Inverter a brick:Tag ;
+    rdfs:label "Inverter" .
+
+tag:Janitor a brick:Tag ;
+    rdfs:label "Janitor" .
+
+tag:Kitchen a brick:Tag ;
+    rdfs:label "Kitchen" .
+
+tag:Last a brick:Tag ;
+    rdfs:label "Last" .
+
+tag:Library a brick:Tag ;
+    rdfs:label "Library" .
+
+tag:Loading a brick:Tag ;
+    rdfs:label "Loading" .
+
+tag:Locally a brick:Tag ;
+    rdfs:label "Locally" .
+
+tag:Louver a brick:Tag ;
+    rdfs:label "Louver" .
+
+tag:Lowest a brick:Tag ;
+    rdfs:label "Lowest" .
+
+tag:MDF a brick:Tag ;
+    rdfs:label "MDF" .
+
+tag:Mail a brick:Tag ;
+    rdfs:label "Mail" .
+
+tag:Manual a brick:Tag ;
+    rdfs:label "Manual" .
+
+tag:Materials a brick:Tag ;
+    rdfs:label "Materials" .
+
+tag:Medical a brick:Tag ;
+    rdfs:label "Medical" .
+
+tag:Meidcal a brick:Tag ;
+    rdfs:label "Meidcal" .
+
+tag:Month a brick:Tag ;
+    rdfs:label "Month" .
+
+tag:Motion a brick:Tag ;
+    rdfs:label "Motion" .
+
+tag:Natural a brick:Tag ;
+    rdfs:label "Natural" .
+
+tag:Network a brick:Tag ;
+    rdfs:label "Network" .
+
+tag:No a brick:Tag ;
+    rdfs:label "No" .
+
+tag:Overload a brick:Tag ;
+    rdfs:label "Overload" .
+
+tag:PAU a brick:Tag ;
+    rdfs:label "PAU" .
+
+tag:PIR a brick:Tag ;
+    rdfs:label "PIR" .
+
+tag:PV a brick:Tag ;
+    rdfs:label "PV" .
+
+tag:Panel a brick:Tag ;
+    rdfs:label "Panel" .
+
+tag:Peak a brick:Tag ;
+    rdfs:label "Peak" .
+
+tag:Phone a brick:Tag ;
+    rdfs:label "Phone" .
+
+tag:Photovoltaic a brick:Tag ;
+    rdfs:label "Photovoltaic" .
+
+tag:Piezoelectric a brick:Tag ;
+    rdfs:label "Piezoelectric" .
+
+tag:Play a brick:Tag ;
+    rdfs:label "Play" .
+
+tag:PlugStrip a brick:Tag ;
+    rdfs:label "PlugStrip" .
+
+tag:Plumbing a brick:Tag ;
+    rdfs:label "Plumbing" .
+
+tag:Potable a brick:Tag ;
+    rdfs:label "Potable" .
+
+tag:Prayer a brick:Tag ;
+    rdfs:label "Prayer" .
+
+tag:Private a brick:Tag ;
+    rdfs:label "Private" .
+
+tag:Production a brick:Tag ;
+    rdfs:label "Production" .
+
+tag:Protect a brick:Tag ;
+    rdfs:label "Protect" .
+
+tag:Push a brick:Tag ;
+    rdfs:label "Push" .
+
+tag:RTU a brick:Tag ;
+    rdfs:label "RTU" .
+
+tag:RVAV a brick:Tag ;
+    rdfs:label "RVAV" .
+
+tag:Radiance a brick:Tag ;
+    rdfs:label "Radiance" .
+
+tag:Radiation a brick:Tag ;
+    rdfs:label "Radiation" .
+
+tag:Rated a brick:Tag ;
+    rdfs:label "Rated" .
+
+tag:Ratio a brick:Tag ;
+    rdfs:label "Ratio" .
+
+tag:Reactive a brick:Tag ;
+    rdfs:label "Reactive" .
+
+tag:Reader a brick:Tag ;
+    rdfs:label "Reader" .
+
+tag:Ready a brick:Tag ;
+    rdfs:label "Ready" .
+
+tag:Real a brick:Tag ;
+    rdfs:label "Real" .
+
+tag:Reception a brick:Tag ;
+    rdfs:label "Reception" .
+
+tag:Recorder a brick:Tag ;
+    rdfs:label "Recorder" .
+
+tag:Recovery a brick:Tag ;
+    rdfs:label "Recovery" .
+
+tag:Region a brick:Tag ;
+    rdfs:label "Region" .
+
+tag:Remotely a brick:Tag ;
+    rdfs:label "Remotely" .
+
+tag:Request a brick:Tag ;
+    rdfs:label "Request" .
+
+tag:Required a brick:Tag ;
+    rdfs:label "Required" .
+
+tag:Rest a brick:Tag ;
+    rdfs:label "Rest" .
+
+tag:Restroom a brick:Tag ;
+    rdfs:label "Restroom" .
+
+tag:Retail a brick:Tag ;
+    rdfs:label "Retail" .
+
+tag:Sash a brick:Tag ;
+    rdfs:label "Sash" .
+
+tag:Schedule a brick:Tag ;
+    rdfs:label "Schedule" .
+
+tag:Server a brick:Tag ;
+    rdfs:label "Server" .
+
+tag:Shaft a brick:Tag ;
+    rdfs:label "Shaft" .
+
+tag:Shared a brick:Tag ;
+    rdfs:label "Shared" .
+
+tag:Short a brick:Tag ;
+    rdfs:label "Short" .
+
+tag:Shutdown a brick:Tag ;
+    rdfs:label "Shutdown" .
+
+tag:Site a brick:Tag ;
+    rdfs:label "Site" .
+
+tag:Sports a brick:Tag ;
+    rdfs:label "Sports" .
+
+tag:Stage a brick:Tag ;
+    rdfs:label "Stage" .
+
+tag:Stages a brick:Tag ;
+    rdfs:label "Stages" .
+
+tag:Staircase a brick:Tag ;
+    rdfs:label "Staircase" .
+
+tag:Storey a brick:Tag ;
+    rdfs:label "Storey" .
+
+tag:Structure a brick:Tag ;
+    rdfs:label "Structure" .
+
+tag:Studio a brick:Tag ;
+    rdfs:label "Studio" .
+
+tag:Suction a brick:Tag ;
+    rdfs:label "Suction" .
+
+tag:Switchgear a brick:Tag ;
+    rdfs:label "Switchgear" .
+
+tag:TETRA a brick:Tag ;
+    rdfs:label "TETRA" .
+
+tag:Team a brick:Tag ;
+    rdfs:label "Team" .
+
+tag:Temporary a brick:Tag ;
+    rdfs:label "Temporary" .
+
+tag:Terminal a brick:Tag ;
+    rdfs:label "Terminal" .
+
+tag:Thermostat a brick:Tag ;
+    rdfs:label "Thermostat" .
+
+tag:Ticketing a brick:Tag ;
+    rdfs:label "Ticketing" .
+
+tag:Timer a brick:Tag ;
+    rdfs:label "Timer" .
+
+tag:Touchpanel a brick:Tag ;
+    rdfs:label "Touchpanel" .
+
+tag:Trace a brick:Tag ;
+    rdfs:label "Trace" .
+
+tag:Tunnel a brick:Tag ;
+    rdfs:label "Tunnel" .
+
+tag:Underfloor a brick:Tag ;
+    rdfs:label "Underfloor" .
+
+tag:VAV a brick:Tag ;
+    rdfs:label "VAV" .
+
+tag:Vent a brick:Tag ;
+    rdfs:label "Vent" .
+
+tag:Visitor a brick:Tag ;
+    rdfs:label "Visitor" .
+
+tag:Wardrobe a brick:Tag ;
+    rdfs:label "Wardrobe" .
+
+tag:Warm a brick:Tag ;
+    rdfs:label "Warm" .
+
+tag:Warmest a brick:Tag ;
+    rdfs:label "Warmest" .
+
+tag:Waste a brick:Tag ;
+    rdfs:label "Waste" .
+
+tag:Weather a brick:Tag ;
+    rdfs:label "Weather" .
+
+tag:Wing a brick:Tag ;
+    rdfs:label "Wing" .
+
+tag:Workshop a brick:Tag ;
+    rdfs:label "Workshop" .
+
+tag:Zenith a brick:Tag ;
+    rdfs:label "Zenith" .
+
+unit:BTU_IT qudt:symbol "Btu_{it}" .
+
+unit:UNITLESS qudt:symbol "U" .
+
+brick:Air_Alarm a owl:Class ;
+    rdfs:label "Air Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Alarm ) ],
+        brick:Alarm ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Point .
+
+brick:Air_Temperature_Alarm a owl:Class ;
+    rdfs:label "Air Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Alarm ) ],
+        brick:Air_Alarm,
+        brick:Temperature_Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with the temperature of air."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Alarm,
+        tag:Point,
+        tag:Temperature .
+
+brick:AreaShape a sh:NodeShape ;
+    sh:property [ a sh:PropertyShape ;
+            sh:datatype xsd:float ;
+            sh:minCount 1 ;
+            sh:path brick:value ],
+        [ a sh:PropertyShape ;
+            sh:in ( unit:FT2 unit:M2 ) ;
+            sh:minCount 1 ;
+            sh:path brick:hasUnit ] .
+
+brick:Baseboard_Radiator a owl:Class ;
+    rdfs:label "Baseboard Radiator" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Radiator _:has_Baseboard ) ],
+        brick:Radiator ;
+    skos:definition "Steam, hydronic, or electric heating device located at or near the floor."@en ;
+    brick:hasAssociatedTag tag:Baseboard,
+        tag:Equipment,
+        tag:Radiator .
+
+brick:Chilled_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Chilled Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Chilled ) ],
+        brick:Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Chilled_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of chilled water"@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Chiller a owl:Class ;
+    rdfs:label "Chiller" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Chiller ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "Refrigerating machine used to transfer heat between fluids. Chillers are either direct expansion with a compressor or absorption type."@en ;
+    brick:hasAssociatedTag tag:Chiller,
+        tag:Equipment .
+
+brick:Collection_Basin_Water a owl:Class,
+        brick:Collection_Basin_Water ;
+    rdfs:label "Collection Basin Water" ;
+    rdfs:seeAlso <https://www.towercomponentsinc.com/cooling-tower-basics-misc-terms-glossary> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Collection _:has_Basin ) ],
+        brick:Water ;
+    skos:definition "Water transiently collected and directed to the sump or pump suction line, typically integral with a cooling tower"@en ;
+    brick:hasAssociatedTag tag:Basin,
+        tag:Collection,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+brick:Cooling_Discharge_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Cooling Discharge Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets discharge air flow for cooling"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Current_Sensor a owl:Class ;
+    rdfs:label "Current Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Current ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Current ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Senses the amperes of electrical current passing through the sensor"@en ;
+    brick:hasAssociatedTag tag:Current,
+        tag:Point,
+        tag:Sensor .
+
+brick:Deionized_Water a owl:Class,
+        brick:Deionized_Water ;
+    rdfs:label "Deionized Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Deionized _:has_Water ) ],
+        brick:Water ;
+    skos:definition "Water which has been purified by removing its ions (constituting the majority of non-particulate contaminants)"@en ;
+    brick:hasAssociatedTag tag:Deionized,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+brick:Demand_Sensor a owl:Class ;
+    rdfs:label "Demand Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Demand ) ],
+        brick:Sensor ;
+    skos:definition "Measures the amount of power consumed by the use of some process; typically found by multiplying the tonnage of a unit (e.g. RTU) by the efficiency rating in kW/ton"@en ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Point,
+        tag:Sensor .
+
+brick:Differential_Pressure_Load_Shed_Status a owl:Class ;
+    rdfs:label "Differential Pressure Load Shed Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Load_Shed_Status,
+        brick:Pressure_Status ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Load,
+        tag:Point,
+        tag:Pressure,
+        tag:Shed,
+        tag:Status .
+
+brick:Discharge_Air_Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Discharge_Air_Temperature_Setpoint,
+        brick:Temperature_Deadband_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature of discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Deadband,
+        tag:Discharge,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Discharge_Air_Temperature_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Discharge Air Temperature Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Proportional_Band_Parameter,
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Band,
+        tag:Discharge,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional,
+        tag:Temperature .
+
+brick:Discharge_Air_Temperature_Reset_Differential_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Temperature Reset Differential Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Differential _:has_Reset _:has_Setpoint ) ],
+        brick:Temperature_Differential_Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Differential,
+        tag:Discharge,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Discharge_Chilled_Water a owl:Class,
+        brick:Discharge_Chilled_Water ;
+    rdfs:label "Discharge Chilled Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled _:has_Discharge ) ],
+        brick:Chilled_Water,
+        brick:Discharge_Water ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Discharge,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+brick:Duration_Sensor a owl:Class ;
+    rdfs:label "Duration Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Duration ) ],
+        brick:Sensor ;
+    skos:definition "Measures the duration of a phenomenon or event"@en ;
+    brick:hasAssociatedTag tag:Duration,
+        tag:Point,
+        tag:Sensor .
+
+brick:Electrical_Power_Sensor a owl:Class ;
+    rdfs:label "Electrical Power Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Power _:has_Electrical ) ],
+        brick:Power_Sensor ;
+    skos:definition "Measures the amount of instantaneous electric power consumed"@en ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Point,
+        tag:Power,
+        tag:Sensor .
+
+brick:Electrical_Room a owl:Class ;
+    rdfs:label "Electrical Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Service_Room ;
+    skos:definition "A class of service rooms that house electrical equipment for a building"@en ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Location,
+        tag:Room,
+        tag:Service,
+        tag:Space .
+
+brick:Emergency_Wash_Station a owl:Class ;
+    rdfs:label "Emergency Wash Station" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Safety _:has_Wash _:has_Station _:has_Emergency ) ],
+        brick:Safety_Equipment ;
+    brick:hasAssociatedTag tag:Emergency,
+        tag:Equipment,
+        tag:Safety,
+        tag:Station,
+        tag:Wash .
+
+brick:Enclosed_Office a owl:Class ;
+    rdfs:label "Enclosed Office" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Enclosed _:has_Office _:has_Room _:has_Space _:has_Location ) ],
+        brick:Office ;
+    skos:definition "A space for individuals to work with walls and a door"@en ;
+    brick:hasAssociatedTag tag:Enclosed,
+        tag:Location,
+        tag:Office,
+        tag:Room,
+        tag:Space .
+
+brick:Energy a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Energy" .
+
+brick:Fluid a owl:Class,
+        brick:Fluid ;
+    rdfs:label "Fluid" ;
+    rdfs:subClassOf _:has_Fluid,
+        brick:Substance ;
+    skos:definition "substance, as a liquid or gas, that is capable of flowing and that changes shape when acted on by a force."@en ;
+    brick:hasAssociatedTag tag:Fluid .
+
+brick:Gain_Parameter a owl:Class ;
+    rdfs:label "Gain Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Gain ) ],
+        brick:PID_Parameter ;
+    brick:hasAssociatedTag tag:Gain,
+        tag:PID,
+        tag:Parameter,
+        tag:Point .
+
+brick:Heating_Valve a owl:Class ;
+    rdfs:label "Heating Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Heat _:has_Equipment ) ],
+        brick:Valve ;
+    skos:definition "A valve that controls air temperature by modulating the amount of hot water flowing through a heating coil"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Heat,
+        tag:Valve .
+
+brick:Hot_Water_Supply_Temperature_Sensor a owl:Class ;
+    rdfs:label "Hot Water Supply Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Hot _:has_Supply ) ],
+        brick:Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Supply_Hot_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of water supplied by a hot water system"@en ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:Point,
+        tag:Sensor,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Humidity a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Humidity" .
+
+brick:Humidity_Parameter a owl:Class ;
+    rdfs:label "Humidity Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Parameter ) ],
+        brick:Parameter ;
+    skos:definition "Parameters relevant to humidity-related systems and points"@en ;
+    brick:hasAssociatedTag tag:Humidity,
+        tag:Parameter,
+        tag:Point .
+
+brick:Load_Shed_Setpoint a owl:Class ;
+    rdfs:label "Load Shed Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Shed _:has_Load _:has_Setpoint ) ],
+        brick:Load_Setpoint ;
+    brick:hasAssociatedTag tag:Load,
+        tag:Point,
+        tag:Setpoint,
+        tag:Shed .
+
+brick:Load_Shed_Status a owl:Class ;
+    rdfs:label "Load Shed Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Load _:has_Shed _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if a load shedding policy is in effect"@en ;
+    brick:hasAssociatedTag tag:Load,
+        tag:Point,
+        tag:Shed,
+        tag:Status .
+
+brick:Luminance a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Luminance" ;
+    qudt:applicableUnit unit:LA,
+        unit:STILB ;
+    owl:sameAs qudtqk:Luminance .
+
+brick:Max_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Cooling Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Cooling_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Flow,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Max_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Heating Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Heat _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Max_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Heating_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Media_Room a owl:Class ;
+    rdfs:label "Media Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Massage _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A class of spaces related to the creation of media"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Massage,
+        tag:Room,
+        tag:Space .
+
+brick:Min_Cooling_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Cooling Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Cool _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Cooling_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Cool,
+        tag:Discharge,
+        tag:Flow,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Min_Heating_Discharge_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Heating Discharge Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Heat _:has_Discharge _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Min_Air_Flow_Setpoint_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Heating_Discharge_Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Heat,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Mixed_Air a owl:Class,
+        brick:Mixed_Air ;
+    rdfs:label "Mixed Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Mixed ) ],
+        brick:Air ;
+    skos:definition "(1) air that contains two or more streams of air. (2) combined outdoor air and recirculated air."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Fluid,
+        tag:Gas,
+        tag:Mixed .
+
+brick:Mode_Command a owl:Class ;
+    rdfs:label "Mode Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Mode _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Controls the operating mode of a device or controller"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Mode,
+        tag:Point .
+
+brick:Occupancy a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Occupancy" .
+
+brick:Occupied_Discharge_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Occupied Discharge Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets discharge air flow when occupied"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Off_Status a owl:Class ;
+    rdfs:label "Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Off _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if a control loop, relay or equipment is off"@en ;
+    brick:hasAssociatedTag tag:Off,
+        tag:Point,
+        tag:Status .
+
+brick:Office a owl:Class ;
+    rdfs:label "Office" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Office _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A class of rooms dedicated for work or study"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Office,
+        tag:Room,
+        tag:Space .
+
+brick:Outdoor_Area a owl:Class ;
+    rdfs:label "Outdoor Area" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Location _:has_Outdoor _:has_Area ) ],
+        brick:Location ;
+    skos:definition "A class of spaces that exist outside of a building"@en ;
+    brick:hasAssociatedTag tag:Area,
+        tag:Location,
+        tag:Outdoor .
+
+brick:Outside_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Outside Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air _:has_Outside ) ],
+        brick:Air_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Outside_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Outside,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Position_Sensor a owl:Class ;
+    rdfs:label "Position Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Position _:has_Sensor ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Position ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the current position of a component in terms of a fraction of its full range of motion"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Position,
+        tag:Sensor .
+
+brick:Pressure_Sensor a owl:Class ;
+    rdfs:label "Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Pressure ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measure the amount of force acting on a unit area"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
+        tag:Sensor .
+
+brick:Pressure_Setpoint a owl:Class ;
+    rdfs:label "Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pressure _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets pressure"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
+        tag:Setpoint .
+
+brick:Pressure_Status a owl:Class ;
+    rdfs:label "Pressure Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Pressure _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates if pressure is within expected bounds"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
+        tag:Status .
+
+brick:Reset_Command a owl:Class ;
+    rdfs:label "Reset Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Reset _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Commands that reset a flag, property or value to its default"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point,
+        tag:Reset .
+
+brick:Return_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Return Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Return _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "The target temperature for return air, often used as an approximation of zone air temperature"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Return,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Return_Condenser_Water a owl:Class,
+        brick:Return_Condenser_Water ;
+    rdfs:label "Return Condenser Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Condenser _:has_Return ) ],
+        brick:Condenser_Water ;
+    skos:definition "In a condenser water loop, this is water being brought away from the condenser side of a heat-rejection device (e.g. chiller). It is the 'warm' side."@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Return,
+        tag:Water .
+
+brick:Return_Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Return Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water _:has_Return ) ],
+        brick:Water_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Return_Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of return water"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Return,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+brick:Room_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Room Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Room _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of room air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Room,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Safety_System a owl:Class ;
+    rdfs:label "Safety System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Safety _:has_System ) ],
+        brick:System ;
+    brick:hasAssociatedTag tag:Safety,
+        tag:System .
+
+brick:Service_Room a owl:Class ;
+    rdfs:label "Service Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Service _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A class of spaces related to the operations of building subsystems, e.g. HVAC, electrical, IT, plumbing, etc"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Service,
+        tag:Space .
+
+brick:Speed_Sensor a owl:Class ;
+    rdfs:label "Speed Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Speed ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Speed ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the magnitude of velocity of some form of movement"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
+        tag:Speed .
+
+brick:Static_Pressure_Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Static Pressure Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Band,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Proportional,
+        tag:Static .
+
+brick:Static_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Static Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Static_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Step_Parameter a owl:Class ;
+    rdfs:label "Step Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Step ) ],
+        brick:PID_Parameter ;
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
+        tag:Step .
+
+brick:Supply_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Temperature setpoint for supply air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature .
+
+brick:Supply_Chilled_Water a owl:Class,
+        brick:Supply_Chilled_Water ;
+    rdfs:label "Supply Chilled Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled _:has_Supply ) ],
+        brick:Chilled_Water,
+        brick:Supply_Water ;
+    owl:equivalentClass brick:Discharge_Chilled_Water ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Supply,
+        tag:Water .
+
+brick:Supply_Condenser_Water a owl:Class,
+        brick:Supply_Condenser_Water ;
+    rdfs:label "Supply Condenser Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Condenser _:has_Supply ) ],
+        brick:Condenser_Water ;
+    skos:definition "In a condenser water loop, this is water being brought to the condenser side of a heat-rejection device (e.g. chiller). It is the 'cold' side."@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Supply,
+        tag:Water .
+
+brick:TimeseriesReference a owl:Class,
+        sh:NodeShape ;
+    skos:definition "Metadata describing where and how the data for a Brick Point is stored" ;
+    sh:property [ a sh:PropertyShape ;
+            sh:class brick:Database ;
+            sh:path brick:storedAt ],
+        [ a sh:PropertyShape ;
+            sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:path brick:hasTimeseriesId ] .
+
+brick:Usage_Sensor a owl:Class ;
+    rdfs:label "Usage Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Usage ) ],
+        brick:Sensor ;
+    skos:definition "Measures the amount of some substance that is consumed or used, over some period of time"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
+        tag:Usage .
+
+brick:Velocity_Pressure_Sensor a owl:Class ;
+    rdfs:label "Velocity Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Velocity ) ],
+        brick:Pressure_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Velocity_Pressure ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the difference between total pressure and static pressure"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Velocity .
+
+brick:Video_Surveillance_Equipment a owl:Class ;
+    rdfs:label "Video Surveillance Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Security _:has_Video _:has_Surveillance ) ],
+        brick:Security_Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Security,
+        tag:Surveillance,
+        tag:Video .
+
+brick:Voltage a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Voltage" ;
+    owl:sameAs qudtqk:Voltage ;
+    skos:definition "Voltage, also referred to as Electric Tension, is the difference between electrical potentials of two points. For an electric field within a medium, (U_{ab} = - \\int_{r_a}^{r_b} E . {dr}), where (E) is electric field strength. For an irrotational electric field, the voltage is independent of the path between the two points (a) and (b)."@en .
+
+brick:Voltage_Sensor a owl:Class ;
+    rdfs:label "Voltage Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Voltage ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Voltage ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the voltage of an electrical device or object"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
+        tag:Voltage .
+
+brick:Water_Meter a owl:Class ;
+    rdfs:label "Water Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment _:has_Water ) ],
+        brick:Meter ;
+    skos:definition "A meter that measures the usage or consumption of water"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Meter,
+        tag:Water .
+
+brick:Water_Pump a owl:Class ;
+    rdfs:label "Water Pump" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Pump _:has_Water ) ],
+        brick:Pump ;
+    skos:definition "A pump that performs work on water"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Pump,
+        tag:Water .
+
+brick:Water_System a owl:Class ;
+    rdfs:label "Water System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_System ) ],
+        brick:Heating_Ventilation_Air_Conditioning_System ;
+    skos:definition "The equipment, devices and conduits that handle the production and distribution of water in a building"@en ;
+    brick:hasAssociatedTag tag:System,
+        tag:Water .
+
+brick:Zone_Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Zone Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Sensor ) ],
+        brick:Air_Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Zone_Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of air in a zone"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Zone .
+
+tag:AED a brick:Tag ;
+    rdfs:label "AED" .
+
+tag:AHU a brick:Tag ;
+    rdfs:label "AHU" .
+
+tag:Access a brick:Tag ;
+    rdfs:label "Access" .
+
+tag:Adjust a brick:Tag ;
+    rdfs:label "Adjust" .
+
+tag:Aid a brick:Tag ;
+    rdfs:label "Aid" .
+
+tag:Bulb a brick:Tag ;
+    rdfs:label "Bulb" .
+
+tag:CRAC a brick:Tag ;
+    rdfs:label "CRAC" .
+
+tag:Camera a brick:Tag ;
+    rdfs:label "Camera" .
+
+tag:Conditioning a brick:Tag ;
+    rdfs:label "Conditioning" .
+
+tag:Conductivity a brick:Tag ;
+    rdfs:label "Conductivity" .
+
+tag:Cooling a brick:Tag ;
+    rdfs:label "Cooling" .
+
+tag:Cycle a brick:Tag ;
+    rdfs:label "Cycle" .
+
+tag:Defibrillator a brick:Tag ;
+    rdfs:label "Defibrillator" .
+
+tag:Deionised a brick:Tag ;
+    rdfs:label "Deionised" .
+
+tag:Deionized a brick:Tag ;
+    rdfs:label "Deionized" .
+
+tag:Delay a brick:Tag ;
+    rdfs:label "Delay" .
+
+tag:Derivative a brick:Tag ;
+    rdfs:label "Derivative" .
+
+tag:Drive a brick:Tag ;
+    rdfs:label "Drive" .
+
+tag:Duct a brick:Tag ;
+    rdfs:label "Duct" .
+
+tag:Duration a brick:Tag ;
+    rdfs:label "Duration" .
+
+tag:Economizer a brick:Tag ;
+    rdfs:label "Economizer" .
+
+tag:Electric a brick:Tag ;
+    rdfs:label "Electric" .
+
+tag:Entrance a brick:Tag ;
+    rdfs:label "Entrance" .
+
+tag:Failure a brick:Tag ;
+    rdfs:label "Failure" .
+
+tag:Fequency a brick:Tag ;
+    rdfs:label "Fequency" .
+
+tag:Food a brick:Tag ;
+    rdfs:label "Food" .
+
+tag:Freeze a brick:Tag ;
+    rdfs:label "Freeze" .
+
+tag:Frost a brick:Tag ;
+    rdfs:label "Frost" .
+
+tag:Fume a brick:Tag ;
+    rdfs:label "Fume" .
+
+tag:Hail a brick:Tag ;
+    rdfs:label "Hail" .
+
+tag:Hood a brick:Tag ;
+    rdfs:label "Hood" .
+
+tag:Humidifier a brick:Tag ;
+    rdfs:label "Humidifier" .
+
+tag:Ice a brick:Tag ;
+    rdfs:label "Ice" .
+
+tag:Illuminance a brick:Tag ;
+    rdfs:label "Illuminance" .
+
+tag:Intake a brick:Tag ;
+    rdfs:label "Intake" .
+
+tag:Isolation a brick:Tag ;
+    rdfs:label "Isolation" .
+
+tag:Lag a brick:Tag ;
+    rdfs:label "Lag" .
+
+tag:Lounge a brick:Tag ;
+    rdfs:label "Lounge" .
+
+tag:Luminaire a brick:Tag ;
+    rdfs:label "Luminaire" .
+
+tag:Maintenance a brick:Tag ;
+    rdfs:label "Maintenance" .
+
+tag:Makeup a brick:Tag ;
+    rdfs:label "Makeup" .
+
+tag:Massage a brick:Tag ;
+    rdfs:label "Massage" .
+
+tag:Mechanical a brick:Tag ;
+    rdfs:label "Mechanical" .
+
+tag:NVR a brick:Tag ;
+    rdfs:label "NVR" .
+
+tag:Oil a brick:Tag ;
+    rdfs:label "Oil" .
+
+tag:Open a brick:Tag ;
+    rdfs:label "Open" .
+
+tag:Operating a brick:Tag ;
+    rdfs:label "Operating" .
+
+tag:Override a brick:Tag ;
+    rdfs:label "Override" .
+
+tag:PM1 a brick:Tag ;
+    rdfs:label "PM1" .
+
+tag:PM10 a brick:Tag ;
+    rdfs:label "PM10" .
+
+tag:PM2.5 a brick:Tag ;
+    rdfs:label "PM2.5" .
+
+tag:Pre a brick:Tag ;
+    rdfs:label "Pre" .
+
+tag:Rain a brick:Tag ;
+    rdfs:label "Rain" .
+
+tag:Riser a brick:Tag ;
+    rdfs:label "Riser" .
+
+tag:Rooftop a brick:Tag ;
+    rdfs:label "Rooftop" .
+
+tag:Shade a brick:Tag ;
+    rdfs:label "Shade" .
+
+tag:Shower a brick:Tag ;
+    rdfs:label "Shower" .
+
+tag:TVOC a brick:Tag ;
+    rdfs:label "TVOC" .
+
+tag:Tank a brick:Tag ;
+    rdfs:label "Tank" .
+
+tag:Torque a brick:Tag ;
+    rdfs:label "Torque" .
+
+tag:Tower a brick:Tag ;
+    rdfs:label "Tower" .
+
+tag:Transformer a brick:Tag ;
+    rdfs:label "Transformer" .
+
+tag:Ventilation a brick:Tag ;
+    rdfs:label "Ventilation" .
+
+tag:Wet a brick:Tag ;
+    rdfs:label "Wet" .
+
+tag:Wheel a brick:Tag ;
+    rdfs:label "Wheel" .
+
+tag:Wind a brick:Tag ;
+    rdfs:label "Wind" .
+
+unit:KiloW qudt:symbol "kW" .
+
+unit:W qudt:symbol "W" .
+
+brick:Air_Temperature_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Air Temperature Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
+        brick:Integral_Time_Parameter,
+        brick:Temperature_Parameter ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Temperature,
+        tag:Time .
+
+brick:CO a owl:Class,
+        brick:CO ;
+    rdfs:label "CO" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_CO ) ],
+        brick:Gas ;
+    skos:definition "Carbon Monoxide in the vapor phase"@en ;
+    brick:hasAssociatedTag tag:CO,
+        tag:Fluid,
+        tag:Gas .
+
+brick:CO2 a owl:Class,
+        brick:CO2 ;
+    rdfs:label "CO2" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_CO2 ) ],
+        brick:Gas ;
+    skos:definition "Carbon Dioxide in the vapor phase"@en ;
+    brick:hasAssociatedTag tag:CO2,
+        tag:Fluid,
+        tag:Gas .
+
+brick:CO2_Sensor a owl:Class ;
+    rdfs:label "CO2 Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_CO2 ) ],
+        brick:Particulate_Matter_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:CO2 ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures properties of CO2"@en ;
+    brick:hasAssociatedTag tag:CO2,
+        tag:Point,
+        tag:Sensor .
+
+brick:CO_Sensor a owl:Class ;
+    rdfs:label "CO Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_CO ) ],
+        brick:Particulate_Matter_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:CO ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures properties of CO"@en ;
+    brick:hasAssociatedTag tag:CO,
+        tag:Point,
+        tag:Sensor .
+
+brick:Condenser_Water a owl:Class,
+        brick:Condenser_Water ;
+    rdfs:label "Condenser Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Condenser ) ],
+        brick:Water ;
+    skos:definition "Water used used to remove heat through condensation"@en ;
+    brick:hasAssociatedTag tag:Condenser,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+brick:Deadband_Setpoint a owl:Class ;
+    rdfs:label "Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Deadband _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets the size of a deadband"@en ;
+    brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Demand_Setpoint a owl:Class ;
+    rdfs:label "Demand Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Demand _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets the rate required for a process"@en ;
+    brick:hasAssociatedTag tag:Demand,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Differential_Pressure_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Differential Pressure Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Deadband _:has_Setpoint ) ],
+        brick:Deadband_Setpoint,
+        brick:Differential_Pressure_Setpoint ;
+    skos:definition "Sets the size of a deadband of differential pressure"@en ;
+    brick:hasAssociatedTag tag:Deadband,
+        tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint .
+
+brick:Differential_Pressure_Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Differential Pressure Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Integral _:has_Time _:has_Parameter _:has_PID ) ],
+        brick:Integral_Time_Parameter ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Time .
+
+brick:Differential_Pressure_Proportional_Band a owl:Class ;
+    rdfs:label "Differential Pressure Proportional Band" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Proportional _:has_Band _:has_PID ) ],
+        brick:Proportional_Band_Parameter ;
+    brick:hasAssociatedTag tag:Band,
+        tag:Differential,
+        tag:PID,
+        tag:Point,
+        tag:Pressure,
+        tag:Proportional .
+
+brick:Differential_Pressure_Sensor a owl:Class ;
+    rdfs:label "Differential Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Differential ) ],
+        brick:Pressure_Sensor ;
+    skos:definition "Measures the difference between two applied pressures"@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Sensor .
+
+brick:Differential_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Differential Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Setpoint ) ],
+        brick:Pressure_Setpoint ;
+    skos:definition "Sets differential pressure"@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint .
+
+brick:Differential_Pressure_Setpoint_Limit a owl:Class ;
+    rdfs:label "Differential Pressure Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Differential _:has_Pressure _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Differential_Pressure_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Differential,
+        tag:Limit,
+        tag:Parameter,
+        tag:Point,
+        tag:Pressure,
+        tag:Setpoint .
+
+brick:Electric_Current a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Electric Current" ;
+    qudt:applicableUnit unit:A,
+        unit:A_Ab,
+        unit:A_Stat,
+        unit:BIOT,
+        unit:KiloA,
+        unit:MicroA,
+        unit:MilliA,
+        unit:NanoA,
+        unit:PicoA ;
+    owl:sameAs qudtqk:ElectricCurrent .
+
+brick:Enthalpy a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Enthalpy" ;
+    owl:sameAs qudtqk:Enthalpy ;
+    skos:definition "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)",
+        "(also known as heat content), thermodynamic quantity equal to the sum of the internal energy of a system plus the product of the pressure volume work done on the system. H = E + pv, where H = enthalpy or total heat content, E = internal energy of the system, p = pressure, and v = volume. (Compare to [[specific enthalpy]].)"@en .
+
+brick:Floor a owl:Class ;
+    rdfs:label "Floor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Floor _:has_Location ) ],
+        brick:Location ;
+    owl:equivalentClass brick:Storey ;
+    skos:definition "A level, typically representing a horizontal aggregation of spaces that are vertically bound. (referring to IFC)"@en ;
+    brick:hasAssociatedTag tag:Floor,
+        tag:Location .
+
+brick:Heat_Exchanger a owl:Class ;
+    rdfs:label "Heat Exchanger" ;
+    rdfs:seeAlso <BEDES> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Heat _:has_Exchanger ) ],
+        brick:HVAC_Equipment ;
+    owl:equivalentClass brick:HX ;
+    skos:definition "A heat exchanger is a piece of equipment built for efficient heat transfer from one medium to another. The media may be separated by a solid wall to prevent mixing or they may be in direct contact"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Exchanger,
+        tag:Heat .
+
+brick:Hot_Water_System a owl:Class ;
+    rdfs:label "Hot Water System" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Water _:has_Hot _:has_System ) ],
+        brick:Water_System ;
+    skos:definition "The equipment, devices and conduits that handle the production and distribution of hot water in a building"@en ;
+    brick:hasAssociatedTag tag:Hot,
+        tag:System,
+        tag:Water .
+
+brick:Laboratory a owl:Class ;
+    rdfs:label "Laboratory" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Laboratory _:has_Room _:has_Location ) ],
+        brick:Room ;
+    skos:definition "facility acceptable to the local, national, or international recognized authority having jurisdiction and which provides uniform testing and examination procedures and standards for meeting design, manufacturing, and factory testing requirements."@en ;
+    brick:hasAssociatedTag tag:Laboratory,
+        tag:Location,
+        tag:Room .
+
+brick:Level a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Level" ;
+    qudt:applicableUnit unit:CentiM,
+        unit:DeciM,
+        unit:FT,
+        unit:IN,
+        unit:KiloM,
+        unit:M,
+        unit:MicroM,
+        unit:MilliM,
+        unit:YD ;
+    qudt:hasDimensionVector <http://qudt.org/vocab/dimensionvector/A0E0L1I0M0H0T0D0> ;
+    rdfs:isDefinedBy <https://brickschema.org/schema/Brick> ;
+    skos:broader qudtqk:Length ;
+    skos:definition "Amount of substance in a container; typically measured in height" .
+
+brick:Max_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Max Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Air_Flow_Setpoint_Limit,
+        brick:Max_Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Measurable a owl:Class ;
+    rdfs:label "Measurable" ;
+    rdfs:subClassOf brick:Class .
+
+brick:PID_Parameter a owl:Class ;
+    rdfs:label "PID Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID ) ],
+        brick:Parameter ;
+    brick:hasAssociatedTag tag:PID,
+        tag:Parameter,
+        tag:Point .
+
+brick:Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Power" ;
+    qudt:applicableUnit unit:HP,
+        unit:HP_Water,
+        unit:KiloW,
+        unit:W ;
+    owl:sameAs qudtqk:Power ;
+    skos:definition "Power is the rate at which work is performed or energy is transmitted, or the amount of energy required or expended for a given unit of time. As a rate of change of work done or the energy of a subsystem, power is: (P = W/t), where (P) is power, (W) is work and {t} is time."@en .
+
+brick:Radiator a owl:Class ;
+    rdfs:label "Radiator" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Radiator ) ],
+        brick:Terminal_Unit ;
+    skos:definition "Heat exchangers designed to transfer thermal energy from one medium to another"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Radiator .
+
+brick:Reset_Setpoint a owl:Class ;
+    rdfs:label "Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Reset _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Setpoints used in reset strategies"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Reset,
+        tag:Setpoint .
+
+brick:Return_Water a owl:Class,
+        brick:Return_Water ;
+    rdfs:label "Return Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Return ) ],
+        brick:Water ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Return,
+        tag:Water .
+
+brick:Safety_Equipment a owl:Class ;
+    rdfs:label "Safety Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Safety _:has_Equipment ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Safety .
+
+brick:Security_Equipment a owl:Class ;
+    rdfs:label "Security Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Security _:has_Equipment ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Security .
+
+brick:Solid a owl:Class,
+        brick:Solid ;
+    rdfs:label "Solid" ;
+    rdfs:subClassOf _:has_Solid,
+        brick:Substance ;
+    skos:definition "one of the three states or phases of matter characterized by stability of dimensions, relative incompressibility, and molecular motion held to limited oscillation."@en ;
+    brick:hasAssociatedTag tag:Solid .
+
+brick:Static_Pressure a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Static Pressure" ;
+    owl:sameAs qudtqk:StaticPressure ;
+    skos:broader brick:Pressure .
+
+brick:Static_Pressure_Sensor a owl:Class ;
+    rdfs:label "Static Pressure Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Pressure _:has_Static ) ],
+        brick:Pressure_Sensor ;
+    skos:definition "Measures resistance to airflow in a heating and cooling system's components and duct work"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
+        tag:Sensor,
+        tag:Static .
+
+brick:Supply_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Supply Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Air_Flow_Setpoint ;
+    owl:equivalentClass brick:Discharge_Air_Flow_Setpoint ;
+    skos:definition "Sets supply air flow rate"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint,
+        tag:Supply .
+
+brick:Supply_Water a owl:Class,
+        brick:Supply_Water ;
+    rdfs:label "Supply Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Supply ) ],
+        brick:Water ;
+    owl:equivalentClass brick:Discharge_Water ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Supply,
+        tag:Water .
+
+brick:System_Status a owl:Class ;
+    rdfs:label "System Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_System _:has_Status ) ],
+        brick:Status ;
+    skos:definition "Indicates properties of the activity of a system"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Status,
+        tag:System .
+
+brick:Telecom_Room a owl:Class ;
+    rdfs:label "Telecom Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Telecom _:has_Room _:has_Space _:has_Location ) ],
+        brick:Room ;
+    skos:definition "A class of spaces used to support telecommuncations and IT equipment"@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room,
+        tag:Space,
+        tag:Telecom .
+
+brick:Temperature_Alarm a owl:Class ;
+    rdfs:label "Temperature Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates the off-normal conditions associated with temperature."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
+        tag:Temperature .
+
+brick:Temperature_High_Reset_Setpoint a owl:Class ;
+    rdfs:label "Temperature High Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_High _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:High,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Temperature_Low_Reset_Setpoint a owl:Class ;
+    rdfs:label "Temperature Low Reset Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Low _:has_Reset _:has_Setpoint ) ],
+        brick:Reset_Setpoint ;
+    brick:hasAssociatedTag tag:Low,
+        tag:Point,
+        tag:Reset,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Temperature_Sensor a owl:Class ;
+    rdfs:label "Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures temperature: the physical property of matter that quantitatively expresses the common notions of hot and cold"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:VFD a owl:Class ;
+    rdfs:label "VFD" ;
+    rdfs:seeAlso <https://xp20.ashrae.org/terminology/index.php?term=vfd&submit=Search> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_VFD ) ],
+        brick:Motor ;
+    skos:definition "Electronic device that varies its output frequency to vary the rotating speed of a motor, given a fixed input frequency. Used with fans or pumps to vary the flow in the system as a function of a maintained pressure."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:VFD .
+
+brick:Velocity_Pressure a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Velocity Pressure" ;
+    owl:sameAs qudtqk:DynamicPressure,
+        brick:Dynamic_Pressure ;
+    skos:broader brick:Pressure ;
+    skos:definition "Dynamic Pressure (indicated with q, or Q, and sometimes called velocity pressure) is the quantity defined by: (q = 1/2 * ρ v^{2}), where (using SI units),  (q) is dynamic pressure in (pascals), (ρ) is fluid density in (kg/m^{3}) (for example, density of air) and (v ) is fluid velocity in (m/s)."@en .
+
+brick:Vertical_Space a owl:Class ;
+    rdfs:label "Vertical Space" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Vertical _:has_Space _:has_Location ) ],
+        brick:Space ;
+    skos:definition "A class of spaces used to connect multiple floors or levels.."@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Space,
+        tag:Vertical .
+
+brick:Water_Flow_Sensor a owl:Class ;
+    rdfs:label "Water Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Water ) ],
+        brick:Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of water"@en ;
+    brick:hasAssociatedTag tag:Flow,
+        tag:Point,
+        tag:Sensor,
+        tag:Water .
+
+brick:Water_Valve a owl:Class ;
+    rdfs:label "Water Valve" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Water _:has_Equipment ) ],
+        brick:Valve ;
+    skos:definition "A valve that modulates the flow of water"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Valve,
+        tag:Water .
+
+brick:Zone a owl:Class ;
+    rdfs:label "Zone" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Zone _:has_Location ) ],
+        brick:Location ;
+    skos:definition "(1) a separately controlled heated or cooled space. (2) one occupied space or several occupied spaces with similar occupancy category, occupant density, zone air distribution effectiveness, and zone primary airflow per unit area. (3) space or group of spaces within a building for which the heating, cooling, or lighting requirements are sufficiently similar that desired conditions can be maintained throughout by a single controlling device."@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Zone .
+
+brick:Zone_Air a owl:Class,
+        brick:Zone_Air ;
+    rdfs:label "Zone Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Zone ) ],
+        brick:Air ;
+    skos:definition "air inside a defined zone (e.g., corridors)."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Fluid,
+        tag:Gas,
+        tag:Zone .
+
+brick:hasUnit a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:range unit:Unit ;
+    skos:definition "The QUDT unit associated with this Brick entity (usually a Brick Point instance or Entity Property)"@en .
+
+tag:Angle a brick:Tag ;
+    rdfs:label "Angle" .
+
+tag:Battery a brick:Tag ;
+    rdfs:label "Battery" .
+
+tag:Chiller a brick:Tag ;
+    rdfs:label "Chiller" .
+
+tag:Elevator a brick:Tag ;
+    rdfs:label "Elevator" .
+
+tag:Entering a brick:Tag ;
+    rdfs:label "Entering" .
+
+tag:Frame a brick:Tag ;
+    rdfs:label "Frame" .
+
+tag:Frequency a brick:Tag ;
+    rdfs:label "Frequency" .
+
+tag:Fresh a brick:Tag ;
+    rdfs:label "Fresh" .
+
+tag:Generator a brick:Tag ;
+    rdfs:label "Generator" .
+
+tag:Grains a brick:Tag ;
+    rdfs:label "Grains" .
+
+tag:HVAC a brick:Tag ;
+    rdfs:label "HVAC" .
+
+tag:Heater a brick:Tag ;
+    rdfs:label "Heater" .
+
+tag:Intercom a brick:Tag ;
+    rdfs:label "Intercom" .
+
+tag:Lead a brick:Tag ;
+    rdfs:label "Lead" .
+
+tag:Leak a brick:Tag ;
+    rdfs:label "Leak" .
+
+tag:Lighting a brick:Tag ;
+    rdfs:label "Lighting" .
+
+tag:Lobby a brick:Tag ;
+    rdfs:label "Lobby" .
+
+tag:Overridden a brick:Tag ;
+    rdfs:label "Overridden" .
+
+tag:Parking a brick:Tag ;
+    rdfs:label "Parking" .
+
+tag:Reheat a brick:Tag ;
+    rdfs:label "Reheat" .
+
+tag:Smoke a brick:Tag ;
+    rdfs:label "Smoke" .
+
+tag:Surveillance a brick:Tag ;
+    rdfs:label "Surveillance" .
+
+tag:Thermal a brick:Tag ;
+    rdfs:label "Thermal" .
+
+tag:Tolerance a brick:Tag ;
+    rdfs:label "Tolerance" .
+
+tag:Variable a brick:Tag ;
+    rdfs:label "Variable" .
+
+tag:Volume a brick:Tag ;
+    rdfs:label "Volume" .
+
+unit:K qudt:symbol "K" .
+
+brick:AHU a owl:Class ;
+    rdfs:label "AHU" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_AHU ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "Assembly consisting of sections containing a fan or fans and other necessary equipment to perform one or more of the following functions: circulating, filtration, heating, cooling, heat recovery, humidifying, dehumidifying, and mixing of air. Is usually connected to an air-distribution system."@en ;
+    brick:hasAssociatedTag tag:AHU,
+        tag:Equipment .
+
+brick:Building a owl:Class ;
+    rdfs:label "Building" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Building _:has_Location ) ],
+        brick:Location ;
+    skos:definition "An independent unit of the built environment with a characteristic spatial structure, intended to serve at least one function or user activity [ISO 12006-2:2013]"@en,
+        "a structure wholly or partially enclosed within exterior walls, or within exterior and party walls, and a roof, affording shelter to persons, animals, or property."@en ;
+    brick:hasAssociatedTag tag:Building,
+        tag:Location .
+
+brick:Building_Meter a owl:Class ;
+    rdfs:label "Building Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment _:has_Building ) ],
+        brick:Meter ;
+    skos:definition "A meter that measures usage or consumption of some media for a whole building"@en ;
+    brick:hasAssociatedTag tag:Building,
+        tag:Equipment,
+        tag:Meter .
+
+brick:Chilled_Water a owl:Class,
+        brick:Chilled_Water ;
+    rdfs:label "Chilled Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Chilled ) ],
+        brick:Water ;
+    skos:definition "water used as a cooling medium (particularly in air-conditioning systems or in processes) at below ambient temperature."@en ;
+    brick:hasAssociatedTag tag:Chilled,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+brick:Class a owl:Class .
+
+brick:Common_Space a owl:Class ;
+    rdfs:label "Common Space" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Common _:has_Space _:has_Location ) ],
+        brick:Space ;
+    skos:definition "A class of spaces that are used by multiple people at the same time"@en ;
+    brick:hasAssociatedTag tag:Common,
+        tag:Location,
+        tag:Space .
+
+brick:Damper a owl:Class ;
+    rdfs:label "Damper" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Damper ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "Element inserted into an air-distribution system or element of an air-distribution system permitting modification of the air resistance of the system and consequently changing the airflow rate or shutting off the airflow."@en ;
+    brick:hasAssociatedTag tag:Damper,
+        tag:Equipment .
+
+brick:Dewpoint_Sensor a owl:Class ;
+    rdfs:label "Dewpoint Sensor" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Dew_point> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Dewpoint ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Dewpoint ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Senses the dewpoint temperature . Dew point is the temperature to which air must be cooled to become saturated with water vapor"@en ;
+    brick:hasAssociatedTag tag:Dewpoint,
+        tag:Point,
+        tag:Sensor .
+
+brick:Disable_Command a owl:Class ;
+    rdfs:label "Disable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Disable _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Commands that disable functionality"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Disable,
+        tag:Point .
+
+brick:Discharge_Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Air_Flow_Setpoint ;
+    skos:definition "Sets discharge air flow"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Electric_Power a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Electric Power" ;
+    qudt:applicableUnit unit:KiloW ;
+    owl:sameAs qudtqk:ElectricPower ;
+    skos:broader brick:Power ;
+    skos:definition "Electric Power is the rate at which electrical energy is transferred by an electric circuit. In the simple case of direct current circuits, electric power can be calculated as the product of the potential difference in the circuit (V) and the amount of current flowing in the circuit (I): (P = VI), where (P) is the power, (V) is the potential difference, and (I) is the current. However, in general electric power is calculated by taking the integral of the vector cross-product of the electrical and magnetic fields over a specified area."@en .
+
+brick:Filter a owl:Class ;
+    rdfs:label "Filter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Filter ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "Device to remove gases from a mixture of gases or to remove solid material from a fluid"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Filter .
+
+brick:Hot_Water a owl:Class,
+        brick:Hot_Water ;
+    rdfs:label "Hot Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Hot ) ],
+        brick:Water ;
+    skos:definition "Hot water used for HVAC heating or supply to hot taps"@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Hot,
+        tag:Liquid,
+        tag:Water .
+
+brick:Meter a owl:Class ;
+    rdfs:label "Meter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Meter _:has_Equipment ) ],
+        brick:Equipment ;
+    skos:definition "A device that measure usage or consumption of some media --- typically a form energy or power."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Meter .
+
+brick:Min_Air_Flow_Setpoint_Limit a owl:Class ;
+    rdfs:label "Min Air Flow Setpoint Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Air _:has_Flow _:has_Limit _:has_Parameter _:has_Setpoint ) ],
+        brick:Air_Flow_Setpoint_Limit,
+        brick:Min_Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Air_Flow_Setpoint."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Occupied_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Occupied Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Occupied _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Occupied,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:On_Off_Command a owl:Class ;
+    rdfs:label "On Off Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Off _:has_Command ) ],
+        brick:Command ;
+    skos:definition "An On/Off Command controls or reports the binary status of a control loop, relay or equipment activity"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Off,
+        tag:On,
+        tag:Point .
+
+brick:Outside_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Outside Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Outside _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of outside air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Outside,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Supply_Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Supply Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Supply _:has_Water _:has_Temperature _:has_Setpoint ) ],
+        brick:Water_Temperature_Setpoint ;
+    skos:definition "Sets temperature of supply water"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
+        tag:Supply,
+        tag:Temperature,
+        tag:Water .
+
+brick:Temperature_Deadband_Setpoint a owl:Class ;
+    rdfs:label "Temperature Deadband Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Deadband _:has_Setpoint ) ],
+        brick:Deadband_Setpoint,
+        brick:Temperature_Setpoint ;
+    skos:definition "Sets the size of a deadband of temperature"@en ;
+    brick:hasAssociatedTag tag:Deadband,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Water_Alarm a owl:Class ;
+    rdfs:label "Water Alarm" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Alarm ) ],
+        brick:Alarm ;
+    skos:definition "An alarm that indicates water leaks."@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point,
+        tag:Water .
+
+brick:Zone_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Zone Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Zone _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of zone air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Zone .
+
+tag:Area a brick:Tag ;
+    rdfs:label "Area" .
+
+tag:Baseboard a brick:Tag ;
+    rdfs:label "Baseboard" .
+
+tag:Control a brick:Tag ;
+    rdfs:label "Control" .
+
+tag:Enclosed a brick:Tag ;
+    rdfs:label "Enclosed" .
+
+tag:Fault a brick:Tag ;
+    rdfs:label "Fault" .
+
+tag:Fixed a brick:Tag ;
+    rdfs:label "Fixed" .
+
+tag:Floor a brick:Tag ;
+    rdfs:label "Floor" .
+
+tag:Interface a brick:Tag ;
+    rdfs:label "Interface" .
+
+tag:Leaving a brick:Tag ;
+    rdfs:label "Leaving" .
+
+tag:Loss a brick:Tag ;
+    rdfs:label "Loss" .
+
+tag:Luminance a brick:Tag ;
+    rdfs:label "Luminance" .
+
+tag:Media a brick:Tag ;
+    rdfs:label "Media" .
+
+tag:Occupancy a brick:Tag ;
+    rdfs:label "Occupancy" .
+
+tag:Outdoor a brick:Tag ;
+    rdfs:label "Outdoor" .
+
+tag:Run a brick:Tag ;
+    rdfs:label "Run" .
+
+tag:Solar a brick:Tag ;
+    rdfs:label "Solar" .
+
+tag:Solid a brick:Tag ;
+    rdfs:label "Solid" .
+
+tag:Switch a brick:Tag ;
+    rdfs:label "Switch" .
+
+tag:Voltage a brick:Tag ;
+    rdfs:label "Voltage" .
+
+tag:Wash a brick:Tag ;
+    rdfs:label "Wash" .
+
+brick:Air_Flow_Setpoint a owl:Class ;
+    rdfs:label "Air Flow Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Flow _:has_Setpoint ) ],
+        brick:Flow_Setpoint ;
+    skos:definition "Sets air flow"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Cooling_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Cooling Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint _:has_Cool ) ],
+        brick:Temperature_Setpoint ;
+    skos:definition "Sets temperature for cooling"@en ;
+    brick:hasAssociatedTag tag:Cool,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Dewpoint a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Dewpoint" ;
+    owl:sameAs qudtqk:DewPointTemperature .
+
+brick:Discharge_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Discharge Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Discharge _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of discharge air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Discharge_Water a owl:Class,
+        brick:Discharge_Water ;
+    rdfs:label "Discharge Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water _:has_Discharge ) ],
+        brick:Water ;
+    brick:hasAssociatedTag tag:Discharge,
+        tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+brick:Gas a owl:Class,
+        brick:Gas ;
+    rdfs:label "Gas" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas ) ],
+        brick:Fluid ;
+    skos:definition "state of matter in which substances exist in the form of nonaggregated molecules and which, within acceptable limits of accuracy, satisfy the ideal gas laws; usually a highly superheated vapor. See [[state]]."@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Gas .
+
+brick:Integral_Time_Parameter a owl:Class ;
+    rdfs:label "Integral Time Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Time _:has_Integral ) ],
+        brick:Time_Parameter ;
+    brick:hasAssociatedTag tag:Integral,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Time .
+
+brick:Liquid a owl:Class,
+        brick:Liquid ;
+    rdfs:label "Liquid" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid ) ],
+        brick:Fluid ;
+    skos:definition "state of matter intermediate between crystalline substances and gases in which the volume of a substance, but not the shape, remains relatively constant."@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid .
+
+brick:Start_Stop_Status a owl:Class ;
+    rdfs:label "Start Stop Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Start _:has_Stop _:has_Status ) ],
+        brick:On_Off_Status ;
+    skos:definition "Indicates the active/inactive status of a control loop (but not equipment activities or relays -- use On/Off for this purpose)"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Start,
+        tag:Status,
+        tag:Stop .
+
+brick:Substance a owl:Class ;
+    rdfs:subClassOf sosa:FeatureOfInterest,
+        brick:Measurable .
+
+brick:Supply_Air a owl:Class,
+        brick:Supply_Air ;
+    rdfs:label "Supply Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Supply ) ],
+        brick:Air ;
+    owl:equivalentClass brick:Discharge_Air ;
+    skos:definition "(1) air delivered by mechanical or natural ventilation to a space, composed of any combination of outdoor air, recirculated air, or transfer air. (2) air entering a space from an air-conditioning, heating, or ventilating apparatus for the purpose of comfort conditioning. Supply air is generally filtered, fan forced, and either heated, cooled, humidified, or dehumidified as necessary to maintain specified conditions. Only the quantity of outdoor air within the supply airflow may be used as replacement air."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Fluid,
+        tag:Gas,
+        tag:Supply .
+
+brick:Temperature_Setpoint a owl:Class ;
+    rdfs:label "Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint ) ],
+        brick:Setpoint ;
+    skos:definition "Sets temperature"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+tag:Basin a brick:Tag ;
+    rdfs:label "Basin" .
+
+tag:Collection a brick:Tag ;
+    rdfs:label "Collection" .
+
+tag:Detection a brick:Tag ;
+    rdfs:label "Detection" .
+
+tag:Direction a brick:Tag ;
+    rdfs:label "Direction" .
+
+tag:Energy a brick:Tag ;
+    rdfs:label "Energy" .
+
+tag:Exchanger a brick:Tag ;
+    rdfs:label "Exchanger" .
+
+tag:Fire a brick:Tag ;
+    rdfs:label "Fire" .
+
+tag:Laboratory a brick:Tag ;
+    rdfs:label "Laboratory" .
+
+tag:Lockout a brick:Tag ;
+    rdfs:label "Lockout" .
+
+tag:Output a brick:Tag ;
+    rdfs:label "Output" .
+
+tag:Preheat a brick:Tag ;
+    rdfs:label "Preheat" .
+
+tag:Stack a brick:Tag ;
+    rdfs:label "Stack" .
+
+tag:Station a brick:Tag ;
+    rdfs:label "Station" .
+
+tag:Storage a brick:Tag ;
+    rdfs:label "Storage" .
+
+tag:Usage a brick:Tag ;
+    rdfs:label "Usage" .
+
+tag:VFD a brick:Tag ;
+    rdfs:label "VFD" .
+
+tag:Velocity a brick:Tag ;
+    rdfs:label "Velocity" .
+
+tag:Vertical a brick:Tag ;
+    rdfs:label "Vertical" .
+
+tag:Video a brick:Tag ;
+    rdfs:label "Video" .
+
+brick:Air_Flow_Sensor a owl:Class ;
+    rdfs:label "Air Flow Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Flow _:has_Air ) ],
+        brick:Flow_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Flow ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the rate of flow of air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Flow,
+        tag:Point,
+        tag:Sensor .
+
+brick:Effective_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Effective Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Effective _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Effective,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:Exhaust_Air a owl:Class,
+        brick:Exhaust_Air ;
+    rdfs:label "Exhaust Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Exhaust ) ],
+        brick:Air ;
+    skos:definition "air that must be removed from a space due to contaminants, regardless of pressurization"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Exhaust,
+        tag:Fluid,
+        tag:Gas .
+
+brick:Heating_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Heating Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Setpoint _:has_Heat ) ],
+        brick:Temperature_Setpoint ;
+    skos:definition "Sets temperature for heating"@en ;
+    brick:hasAssociatedTag tag:Heat,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+brick:On_Off_Status a owl:Class ;
+    rdfs:label "On Off Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_On _:has_Off _:has_Status ) ],
+        brick:Off_Status,
+        brick:On_Status,
+        brick:Status ;
+    skos:definition "Indicates the on/off status of a control loop, relay or equipment"@en ;
+    brick:hasAssociatedTag tag:Off,
+        tag:On,
+        tag:Point,
+        tag:Status .
+
+brick:Particulate_Matter_Sensor a owl:Class ;
+    rdfs:label "Particulate Matter Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Particulate _:has_Matter ) ],
+        brick:Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air_Quality ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Detects pollutants in the ambient air"@en ;
+    brick:hasAssociatedTag tag:Matter,
+        tag:Particulate,
+        tag:Point,
+        tag:Sensor .
+
+brick:Proportional_Band_Parameter a owl:Class ;
+    rdfs:label "Proportional Band Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_PID _:has_Proportional _:has_Band _:has_Parameter _:has_PID ) ],
+        brick:PID_Parameter ;
+    brick:hasAssociatedTag tag:Band,
+        tag:PID,
+        tag:Parameter,
+        tag:Point,
+        tag:Proportional .
+
+brick:Relative_Humidity_Sensor a owl:Class ;
+    rdfs:label "Relative Humidity Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Humidity _:has_Air _:has_Relative ) ],
+        brick:Humidity_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Relative_Humidity ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the present state of absolute humidity relative to a maximum humidity given the same temperature"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Point,
+        tag:Relative,
+        tag:Sensor .
+
+brick:Static_Pressure_Setpoint a owl:Class ;
+    rdfs:label "Static Pressure Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Static _:has_Pressure _:has_Setpoint ) ],
+        brick:Pressure_Setpoint ;
+    skos:definition "Sets static pressure"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Pressure,
+        tag:Setpoint,
+        tag:Static .
+
+brick:Terminal_Unit a owl:Class ;
+    rdfs:label "Terminal Unit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment [ a owl:Restriction ;
+                        owl:hasValue tag:Terminal ;
+                        owl:onProperty brick:hasTag ] _:has_Unit ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "A device that regulates the volumetric flow rate and/or the temperature of the controlled medium."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Terminal,
+        tag:Unit .
+
+brick:Unoccupied_Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Unoccupied Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Unoccupied _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Air_Temperature_Setpoint ;
+    skos:definition "Sets temperature of air when unoccupied"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Unoccupied .
+
+brick:Valve a owl:Class ;
+    rdfs:label "Valve" ;
+    rdfs:seeAlso <https://en.wikipedia.org/wiki/Valve> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Valve _:has_Equipment ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "A device that regulates, directs or controls the flow of a fluid by opening, closing or partially obstructing various passageways"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Valve .
+
+tag:Average a brick:Tag ;
+    rdfs:label "Average" .
+
+tag:CO a brick:Tag ;
+    rdfs:label "CO" .
+
+tag:Coil a brick:Tag ;
+    rdfs:label "Coil" .
+
+tag:Distribution a brick:Tag ;
+    rdfs:label "Distribution" .
+
+tag:Gain a brick:Tag ;
+    rdfs:label "Gain" .
+
+tag:Motor a brick:Tag ;
+    rdfs:label "Motor" .
+
+tag:Standby a brick:Tag ;
+    rdfs:label "Standby" .
+
+brick:Air_Quality a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Air Quality" .
+
+brick:Discharge_Air a owl:Class,
+        brick:Discharge_Air ;
+    rdfs:label "Discharge Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Discharge ) ],
+        brick:Air ;
+    skos:definition "the air exiting the registers (vents)."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Discharge,
+        tag:Fluid,
+        tag:Gas .
+
+brick:Relative_Humidity a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Relative Humidity" ;
+    qudt:applicableUnit unit:UNITLESS ;
+    owl:sameAs qudtqk:RelativeHumidity ;
+    skos:broader brick:Humidity ;
+    skos:definition "Relative Humidity} is the ratio of the partial pressure of water vapor in an air-water mixture to the saturated vapor pressure of water at a prescribed temperature. The relative humidity of air depends not only on temperature but also on the pressure of the system of interest. Relative Humidity is also referred to as \\text{Relative Partial Pressure. Relative partial pressure is often referred to as (RH) and expressed in percent."@en .
+
+brick:System a owl:Class ;
+    rdfs:label "System" ;
+    rdfs:subClassOf _:has_System,
+        brick:Class ;
+    skos:definition "A System is a combination of equipment and auxiliary devices (e.g., controls, accessories, interconnecting means, and termi­nal elements) by which energy is transformed so it performs a specific function such as HVAC, service water heating, or lighting. (ASHRAE Dictionary)." ;
+    brick:hasAssociatedTag tag:System .
+
+brick:Water_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Water Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Water _:has_Temperature _:has_Setpoint ) ],
+        brick:Temperature_Setpoint ;
+    skos:definition "Sets temperature of water"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint,
+        tag:Temperature,
+        tag:Water .
+
+tag:Bypass a brick:Tag ;
+    rdfs:label "Bypass" .
+
+tag:Current a brick:Tag ;
+    rdfs:label "Current" .
+
+tag:Dewpoint a brick:Tag ;
+    rdfs:label "Dewpoint" .
+
+tag:Domestic a brick:Tag ;
+    rdfs:label "Domestic" .
+
+tag:Mixed a brick:Tag ;
+    rdfs:label "Mixed" .
+
+tag:Start a brick:Tag ;
+    rdfs:label "Start" .
+
+tag:Stop a brick:Tag ;
+    rdfs:label "Stop" .
+
+tag:Telecom a brick:Tag ;
+    rdfs:label "Telecom" .
+
+tag:Unit a brick:Tag ;
+    rdfs:label "Unit" .
+
+brick:Air_Humidity_Setpoint a owl:Class ;
+    rdfs:label "Air Humidity Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Humidity _:has_Setpoint _:has_Air ) ],
+        brick:Humidity_Setpoint ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Humidity,
+        tag:Point,
+        tag:Setpoint .
+
+brick:Air_Temperature_Sensor a owl:Class ;
+    rdfs:label "Air Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Air ) ],
+        brick:Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Air ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Sensor,
+        tag:Temperature .
+
+brick:Electrical_Equipment a owl:Class ;
+    rdfs:label "Electrical Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Electrical _:has_Equipment ) ],
+        brick:Equipment ;
+    brick:hasAssociatedTag tag:Electrical,
+        tag:Equipment .
+
+brick:Enable_Command a owl:Class ;
+    rdfs:label "Enable Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Enable _:has_Command ) ],
+        brick:Command ;
+    skos:definition "Commands that enable functionality"@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Enable,
+        tag:Point .
+
+brick:Fan a owl:Class ;
+    rdfs:label "Fan" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Equipment _:has_Fan ) ],
+        brick:HVAC_Equipment ;
+    skos:definition "Any device with two or more blades or vanes attached to a rotating shaft used to produce an airflow for the purpose of comfort, ventilation, exhaust, heating, cooling, or any other gaseous transport."@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:Fan .
+
+brick:Max_Limit a owl:Class ;
+    rdfs:label "Max Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Max _:has_Limit _:has_Parameter ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places an upper bound on the range of permitted values of a Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Max,
+        tag:Parameter,
+        tag:Point .
+
+brick:Pressure a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Pressure" ;
+    qudt:applicableUnit unit:BARYE,
+        unit:N-PER-M2,
+        unit:PA ;
+    owl:sameAs qudtqk:Pressure .
+
+brick:Water_Temperature_Sensor a owl:Class ;
+    rdfs:label "Water Temperature Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor _:has_Temperature _:has_Water ) ],
+        brick:Temperature_Sensor ;
+    owl:equivalentClass [ owl:intersectionOf ( [ a owl:Restriction ;
+                        owl:hasValue brick:Temperature ;
+                        owl:onProperty brick:measures ] [ a owl:Restriction ;
+                        owl:hasValue brick:Water ;
+                        owl:onProperty brick:measures ] ) ] ;
+    skos:definition "Measures the temperature of water"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor,
+        tag:Temperature,
+        tag:Water .
+
+tag:Box a brick:Tag ;
+    rdfs:label "Box" .
+
+tag:Disable a brick:Tag ;
+    rdfs:label "Disable" .
+
+tag:Effective a brick:Tag ;
+    rdfs:label "Effective" .
+
+tag:Mode a brick:Tag ;
+    rdfs:label "Mode" .
+
+tag:Office a brick:Tag ;
+    rdfs:label "Office" .
+
+tag:Radiator a brick:Tag ;
+    rdfs:label "Radiator" .
+
+tag:Relative a brick:Tag ;
+    rdfs:label "Relative" .
+
+tag:Steam a brick:Tag ;
+    rdfs:label "Steam" .
+
+brick:Min_Limit a owl:Class ;
+    rdfs:label "Min Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Min _:has_Limit _:has_Parameter ) ],
+        brick:Limit ;
+    skos:definition "A parameter that places a lower bound on the range of permitted values of a Setpoint."@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Min,
+        tag:Parameter,
+        tag:Point .
+
+brick:Outside_Air a owl:Class,
+        brick:Outside_Air ;
+    rdfs:label "Outside Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Outside ) ],
+        brick:Air ;
+    skos:definition "air external to a defined zone (e.g., corridors)."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Fluid,
+        tag:Gas,
+        tag:Outside .
+
+brick:Return_Air a owl:Class,
+        brick:Return_Air ;
+    rdfs:label "Return Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air _:has_Return ) ],
+        brick:Air ;
+    skos:definition "air removed from a space to be recirculated or exhausted. Air extracted from a space and totally or partially returned to an air conditioner, furnace, or other heating, cooling, or ventilating system."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Fluid,
+        tag:Gas,
+        tag:Return .
+
+brick:Space a owl:Class ;
+    rdfs:label "Space" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Space _:has_Location ) ],
+        brick:Location ;
+    skos:definition "A part of the physical world or a virtual world whose 3D spatial extent is bounded actually or theoretically, and provides for certain functions within the zone it is contained in."@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Space .
+
+tag:Common a brick:Tag ;
+    rdfs:label "Common" .
+
+tag:Enthalpy a brick:Tag ;
+    rdfs:label "Enthalpy" .
+
+tag:Damper a brick:Tag ;
+    rdfs:label "Damper" .
+
+tag:Matter a brick:Tag ;
+    rdfs:label "Matter" .
+
+tag:Particulate a brick:Tag ;
+    rdfs:label "Particulate" .
+
+tag:Position a brick:Tag ;
+    rdfs:label "Position" .
+
+tag:Pump a brick:Tag ;
+    rdfs:label "Pump" .
+
+tag:Step a brick:Tag ;
+    rdfs:label "Step" .
+
+brick:Limit a owl:Class ;
+    rdfs:label "Limit" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter _:has_Limit ) ],
+        brick:Parameter ;
+    skos:definition "A parameter that places a lower or upper bound on the range of permitted values of a Setpoint."@en,
+        "A parameter that places an upper or lower bound on the range of permitted values of another point"@en ;
+    brick:hasAssociatedTag tag:Limit,
+        tag:Parameter,
+        tag:Point .
+
+brick:Parameter a owl:Class ;
+    rdfs:label "Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Parameter ) ],
+        brick:Point ;
+    owl:disjointWith brick:Alarm,
+        brick:Command,
+        brick:Sensor,
+        brick:Setpoint,
+        brick:Status ;
+    skos:definition "Parameter points are configuration settings used to guide the operation of equipment and control systems; for example they may provide bounds on valid setpoint values"@en ;
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point .
+
+brick:Point a owl:Class ;
+    rdfs:label "Point" ;
+    rdfs:subClassOf _:has_Point,
+        brick:Class ;
+    brick:hasAssociatedTag tag:Point .
+
+brick:value a owl:DatatypeProperty,
+        owl:ObjectProperty ;
+    rdfs:subPropertyOf qudt:value ;
+    skos:definition "The basic value of an entity property" .
+
+tag:CO2 a brick:Tag ;
+    rdfs:label "CO2" .
+
+tag:Filter a brick:Tag ;
+    rdfs:label "Filter" .
+
+tag:Building a brick:Tag ;
+    rdfs:label "Building" .
+
+tag:Electrical a brick:Tag ;
+    rdfs:label "Electrical" .
+
+tag:Level a brick:Tag ;
+    rdfs:label "Level" .
+
+tag:Medium a brick:Tag ;
+    rdfs:label "Medium" .
+
+tag:Safety a brick:Tag ;
+    rdfs:label "Safety" .
+
+tag:Security a brick:Tag ;
+    rdfs:label "Security" .
+
+tag:Service a brick:Tag ;
+    rdfs:label "Service" .
+
+tag:Speed a brick:Tag ;
+    rdfs:label "Speed" .
+
+brick:Air_Temperature_Setpoint a owl:Class ;
+    rdfs:label "Air Temperature Setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Air _:has_Temperature _:has_Setpoint ) ],
+        brick:Temperature_Setpoint ;
+    skos:definition "Sets temperature of air"@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Point,
+        tag:Setpoint,
+        tag:Temperature .
+
+tag:Demand a brick:Tag ;
+    rdfs:label "Demand" .
+
+tag:Meter a brick:Tag ;
+    rdfs:label "Meter" .
+
+brick:Temperature_Parameter a owl:Class ;
+    rdfs:label "Temperature Parameter" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Temperature _:has_Parameter ) ],
+        brick:Parameter ;
+    skos:definition "Parameters relevant to temperature-related systems and points"@en ;
+    brick:hasAssociatedTag tag:Parameter,
+        tag:Point,
+        tag:Temperature .
+
+tag:Power a brick:Tag ;
+    rdfs:label "Power" .
+
+brick:Location a owl:Class ;
+    rdfs:label "Location" ;
+    rdfs:subClassOf _:has_Location,
+        brick:Class ;
+    brick:hasAssociatedTag tag:Location .
+
+tag:Emergency a brick:Tag ;
+    rdfs:label "Emergency" .
+
+tag:On a brick:Tag ;
+    rdfs:label "On" .
+
+brick:EntityProperty a owl:Class ;
+    rdfs:subClassOf owl:ObjectProperty .
+
+brick:Flow a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Flow" ;
+    owl:sameAs qudtqk:VolumeFlowRate .
+
+tag:Condenser a brick:Tag ;
+    rdfs:label "Condenser" .
+
+tag:Fan a brick:Tag ;
+    rdfs:label "Fan" .
+
+brick:Water a owl:Class,
+        brick:Water ;
+    rdfs:label "Water" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Liquid _:has_Water ) ],
+        brick:Liquid ;
+    skos:definition "transparent, odorless, tasteless liquid; a compound of hydrogen and oxygen (H2O), containing 11.188% hydrogen and 88.812% oxygen by mass; freezing at 32°F (0°C); boiling near 212°F (100°C)."@en ;
+    brick:hasAssociatedTag tag:Fluid,
+        tag:Liquid,
+        tag:Water .
+
+tag:Off a brick:Tag ;
+    rdfs:label "Off" .
+
+brick:Setpoint a owl:Class ;
+    rdfs:label "Setpoint" ;
+    rdfs:seeAlso <https://xp20.ashrae.org/terminology/index.php?term=setpoint>,
+        "https://xp20.ashrae.org/terminology/index.php?term=setpoint" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Setpoint ) ],
+        brick:Point ;
+    owl:disjointWith brick:Alarm,
+        brick:Command,
+        brick:Parameter,
+        brick:Sensor,
+        brick:Status ;
+    skos:definition "A Setpoint is an input value at which the desired property is set"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Setpoint .
+
+tag:Enable a brick:Tag ;
+    rdfs:label "Enable" .
+
+tag:Integral a brick:Tag ;
+    rdfs:label "Integral" .
+
+tag:Low a brick:Tag ;
+    rdfs:label "Low" .
+
+tag:Unoccupied a brick:Tag ;
+    rdfs:label "Unoccupied" .
+
+brick:Equipment a owl:Class ;
+    rdfs:label "Equipment" ;
+    rdfs:subClassOf _:has_Equipment,
+        brick:Class ;
+    skos:definition "devices that serve all or part of the building and may include electric power, lighting, transportation, or service water heating, including, but not limited to, furnaces, boilers, air conditioners, heat pumps, chillers, water heaters, lamps, luminaires, ballasts, elevators, escalators, or other devices or installations."@en ;
+    brick:hasAssociatedTag tag:Equipment .
+
+tag:Band a brick:Tag ;
+    rdfs:label "Band" .
+
+tag:Gas a brick:Tag ;
+    rdfs:label "Gas" .
+
+tag:Shed a brick:Tag ;
+    rdfs:label "Shed" .
+
+tag:Zone a brick:Tag ;
+    rdfs:label "Zone" .
+
+brick:Alarm a owl:Class ;
+    rdfs:label "Alarm" ;
+    rdfs:seeAlso <https://xp20.ashrae.org/terminology/index.php?term=alarm> ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Alarm ) ],
+        brick:Point ;
+    owl:disjointWith brick:Command,
+        brick:Parameter,
+        brick:Sensor,
+        brick:Setpoint,
+        brick:Status ;
+    skos:definition "Alarm points are signals (either audible or visual) that alert an operator to an off-normal condition which requires some form of corrective action"@en ;
+    brick:hasAssociatedTag tag:Alarm,
+        tag:Point .
+
+brick:HVAC_Equipment a owl:Class ;
+    rdfs:label "HVAC Equipment" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_HVAC _:has_Equipment ) ],
+        brick:Equipment ;
+    skos:definition "See Heating_Ventilation_Air_Conditioning_System"@en ;
+    brick:hasAssociatedTag tag:Equipment,
+        tag:HVAC .
+
+tag:Deadband a brick:Tag ;
+    rdfs:label "Deadband" .
+
+tag:High a brick:Tag ;
+    rdfs:label "High" .
+
+tag:Proportional a brick:Tag ;
+    rdfs:label "Proportional" .
+
+tag:Valve a brick:Tag ;
+    rdfs:label "Valve" .
+
+tag:Occupied a brick:Tag ;
+    rdfs:label "Occupied" .
+
+tag:Time a brick:Tag ;
+    rdfs:label "Time" .
+
+brick:Air a owl:Class,
+        brick:Air ;
+    rdfs:label "Air" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Fluid _:has_Gas _:has_Air ) ],
+        brick:Gas ;
+    skos:definition "the invisible gaseous substance surrounding the earth, a mixture mainly of oxygen and nitrogen."@en ;
+    brick:hasAssociatedTag tag:Air,
+        tag:Fluid,
+        tag:Gas .
+
+brick:Command a owl:Class ;
+    rdfs:label "Command" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Command ) ],
+        brick:Point ;
+    owl:disjointWith brick:Alarm,
+        brick:Parameter,
+        brick:Sensor,
+        brick:Setpoint,
+        brick:Status ;
+    skos:definition "A Command is an output point that directly determines the behavior of equipment and/or affects relevant operational points."@en ;
+    brick:hasAssociatedTag tag:Command,
+        tag:Point .
+
+tag:Exhaust a brick:Tag ;
+    rdfs:label "Exhaust" .
+
+brick:Temperature a qudt:QuantityKind,
+        brick:Quantity ;
+    rdfs:label "Temperature" ;
+    qudt:applicableUnit unit:DEG_R,
+        unit:K ;
+    owl:sameAs qudtqk:ThermodynamicTemperature .
+
+tag:Load a brick:Tag ;
+    rdfs:label "Load" .
+
+tag:Humidity a brick:Tag ;
+    rdfs:label "Humidity" .
+
+tag:Max a brick:Tag ;
+    rdfs:label "Max" .
+
+tag:Min a brick:Tag ;
+    rdfs:label "Min" .
+
+tag:Chilled a brick:Tag ;
+    rdfs:label "Chilled" .
+
+brick:Status a owl:Class ;
+    rdfs:label "Status" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Status ) ],
+        brick:Point ;
+    owl:disjointWith brick:Alarm,
+        brick:Command,
+        brick:Parameter,
+        brick:Sensor,
+        brick:Setpoint ;
+    skos:definition "A Status is input point that reports the current operating mode, state, position, or condition of an item. Statuses are observations and should be considered 'read-only'"@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Status .
+
+tag:Liquid a brick:Tag ;
+    rdfs:label "Liquid" .
+
+tag:Outside a brick:Tag ;
+    rdfs:label "Outside" .
+
+tag:Reset a brick:Tag ;
+    rdfs:label "Reset" .
+
+brick:Room a owl:Class ;
+    rdfs:label "Room" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Room _:has_Location ) ],
+        brick:Space ;
+    skos:definition "Base class for all more specific room types."@en ;
+    brick:hasAssociatedTag tag:Location,
+        tag:Room .
+
+tag:System a brick:Tag ;
+    rdfs:label "System" .
+
+tag:Static a brick:Tag ;
+    rdfs:label "Static" .
+
+tag:Cool a brick:Tag ;
+    rdfs:label "Cool" .
+
+tag:Return a brick:Tag ;
+    rdfs:label "Return" .
+
+brick:Sensor a owl:Class ;
+    rdfs:label "Sensor" ;
+    rdfs:seeAlso "https://xp20.ashrae.org/terminology/index.php?term=Sensor" ;
+    rdfs:subClassOf [ owl:intersectionOf ( _:has_Point _:has_Sensor ) ],
+        brick:Point ;
+    owl:disjointWith brick:Alarm,
+        brick:Command,
+        brick:Parameter,
+        brick:Setpoint,
+        brick:Status ;
+    skos:definition "A Sensor is an input point that represents the value of a device or instrument designed to detect and measure a variable (ASHRAE Dictionary)."@en ;
+    brick:hasAssociatedTag tag:Point,
+        tag:Sensor .
+
+tag:Fluid a brick:Tag ;
+    rdfs:label "Fluid" .
+
+tag:PID a brick:Tag ;
+    rdfs:label "PID" .
+
+tag:Alarm a brick:Tag ;
+    rdfs:label "Alarm" .
+
+tag:Command a brick:Tag ;
+    rdfs:label "Command" .
+
+tag:Hot a brick:Tag ;
+    rdfs:label "Hot" .
+
+tag:Limit a brick:Tag ;
+    rdfs:label "Limit" .
+
+tag:Differential a brick:Tag ;
+    rdfs:label "Differential" .
+
+tag:Heat a brick:Tag ;
+    rdfs:label "Heat" .
+
+tag:Status a brick:Tag ;
+    rdfs:label "Status" .
+
+tag:Room a brick:Tag ;
+    rdfs:label "Room" .
+
+brick:Quantity a owl:Class ;
+    rdfs:subClassOf skos:Concept,
+        sosa:ObservableProperty,
+        brick:Measurable .
+
+tag:Discharge a brick:Tag ;
+    rdfs:label "Discharge" .
+
+tag:Space a brick:Tag ;
+    rdfs:label "Space" .
+
+tag:Flow a brick:Tag ;
+    rdfs:label "Flow" .
+
+tag:Supply a brick:Tag ;
+    rdfs:label "Supply" .
+
+tag:Pressure a brick:Tag ;
+    rdfs:label "Pressure" .
+
+tag:Location a brick:Tag ;
+    rdfs:label "Location" .
+
+tag:Parameter a brick:Tag ;
+    rdfs:label "Parameter" .
+
+tag:Equipment a brick:Tag ;
+    rdfs:label "Equipment" .
+
+tag:Water a brick:Tag ;
+    rdfs:label "Water" .
+
+tag:Temperature a brick:Tag ;
+    rdfs:label "Temperature" .
+
+brick:measures a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:domain brick:Point ;
+    rdfs:range brick:Measurable ;
+    owl:inverseOf brick:isMeasuredBy ;
+    skos:definition "The subject measures a quantity or substance given by the object"@en .
+
+tag:Sensor a brick:Tag ;
+    rdfs:label "Sensor" .
+
+tag:Setpoint a brick:Tag ;
+    rdfs:label "Setpoint" .
+
+tag:Air a brick:Tag ;
+    rdfs:label "Air" .
+
+brick:hasTag a owl:AsymmetricProperty,
+        owl:IrreflexiveProperty,
+        owl:ObjectProperty ;
+    rdfs:range brick:Tag ;
+    owl:inverseOf brick:isTagOf ;
+    skos:definition "The subject has the given tag"@en .
+
+brick:Tag a owl:Class .
+
+tag:Point a brick:Tag ;
+    rdfs:label "Point" .
+
+_:has_AED a owl:Restriction ;
+    owl:hasValue tag:AED ;
+    owl:onProperty brick:hasTag .
+
+_:has_AHU a owl:Restriction ;
+    owl:hasValue tag:AHU ;
+    owl:onProperty brick:hasTag .
+
+_:has_Access a owl:Restriction ;
+    owl:hasValue tag:Access ;
+    owl:onProperty brick:hasTag .
+
+_:has_Adjust a owl:Restriction ;
+    owl:hasValue tag:Adjust ;
+    owl:onProperty brick:hasTag .
+
+_:has_Aid a owl:Restriction ;
+    owl:hasValue tag:Aid ;
+    owl:onProperty brick:hasTag .
+
+_:has_Bulb a owl:Restriction ;
+    owl:hasValue tag:Bulb ;
+    owl:onProperty brick:hasTag .
+
+_:has_CRAC a owl:Restriction ;
+    owl:hasValue tag:CRAC ;
+    owl:onProperty brick:hasTag .
+
+_:has_Camera a owl:Restriction ;
+    owl:hasValue tag:Camera ;
+    owl:onProperty brick:hasTag .
+
+_:has_Conditioning a owl:Restriction ;
+    owl:hasValue tag:Conditioning ;
+    owl:onProperty brick:hasTag .
+
+_:has_Conductivity a owl:Restriction ;
+    owl:hasValue tag:Conductivity ;
+    owl:onProperty brick:hasTag .
+
+_:has_Cooling a owl:Restriction ;
+    owl:hasValue tag:Cooling ;
+    owl:onProperty brick:hasTag .
+
+_:has_Cycle a owl:Restriction ;
+    owl:hasValue tag:Cycle ;
+    owl:onProperty brick:hasTag .
+
+_:has_Defibrillator a owl:Restriction ;
+    owl:hasValue tag:Defibrillator ;
+    owl:onProperty brick:hasTag .
+
+_:has_Deionised a owl:Restriction ;
+    owl:hasValue tag:Deionised ;
+    owl:onProperty brick:hasTag .
+
+_:has_Deionized a owl:Restriction ;
+    owl:hasValue tag:Deionized ;
+    owl:onProperty brick:hasTag .
+
+_:has_Delay a owl:Restriction ;
+    owl:hasValue tag:Delay ;
+    owl:onProperty brick:hasTag .
+
+_:has_Derivative a owl:Restriction ;
+    owl:hasValue tag:Derivative ;
+    owl:onProperty brick:hasTag .
+
+_:has_Drive a owl:Restriction ;
+    owl:hasValue tag:Drive ;
+    owl:onProperty brick:hasTag .
+
+_:has_Duct a owl:Restriction ;
+    owl:hasValue tag:Duct ;
+    owl:onProperty brick:hasTag .
+
+_:has_Duration a owl:Restriction ;
+    owl:hasValue tag:Duration ;
+    owl:onProperty brick:hasTag .
+
+_:has_Economizer a owl:Restriction ;
+    owl:hasValue tag:Economizer ;
+    owl:onProperty brick:hasTag .
+
+_:has_Electric a owl:Restriction ;
+    owl:hasValue tag:Electric ;
+    owl:onProperty brick:hasTag .
+
+_:has_Entrance a owl:Restriction ;
+    owl:hasValue tag:Entrance ;
+    owl:onProperty brick:hasTag .
+
+_:has_Failure a owl:Restriction ;
+    owl:hasValue tag:Failure ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fequency a owl:Restriction ;
+    owl:hasValue tag:Fequency ;
+    owl:onProperty brick:hasTag .
+
+_:has_Food a owl:Restriction ;
+    owl:hasValue tag:Food ;
+    owl:onProperty brick:hasTag .
+
+_:has_Freeze a owl:Restriction ;
+    owl:hasValue tag:Freeze ;
+    owl:onProperty brick:hasTag .
+
+_:has_Frost a owl:Restriction ;
+    owl:hasValue tag:Frost ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fume a owl:Restriction ;
+    owl:hasValue tag:Fume ;
+    owl:onProperty brick:hasTag .
+
+_:has_Hail a owl:Restriction ;
+    owl:hasValue tag:Hail ;
+    owl:onProperty brick:hasTag .
+
+_:has_Hood a owl:Restriction ;
+    owl:hasValue tag:Hood ;
+    owl:onProperty brick:hasTag .
+
+_:has_Humidifier a owl:Restriction ;
+    owl:hasValue tag:Humidifier ;
+    owl:onProperty brick:hasTag .
+
+_:has_Ice a owl:Restriction ;
+    owl:hasValue tag:Ice ;
+    owl:onProperty brick:hasTag .
+
+_:has_Illuminance a owl:Restriction ;
+    owl:hasValue tag:Illuminance ;
+    owl:onProperty brick:hasTag .
+
+_:has_Intake a owl:Restriction ;
+    owl:hasValue tag:Intake ;
+    owl:onProperty brick:hasTag .
+
+_:has_Isolation a owl:Restriction ;
+    owl:hasValue tag:Isolation ;
+    owl:onProperty brick:hasTag .
+
+_:has_Lag a owl:Restriction ;
+    owl:hasValue tag:Lag ;
+    owl:onProperty brick:hasTag .
+
+_:has_Lounge a owl:Restriction ;
+    owl:hasValue tag:Lounge ;
+    owl:onProperty brick:hasTag .
+
+_:has_Luminaire a owl:Restriction ;
+    owl:hasValue tag:Luminaire ;
+    owl:onProperty brick:hasTag .
+
+_:has_Maintenance a owl:Restriction ;
+    owl:hasValue tag:Maintenance ;
+    owl:onProperty brick:hasTag .
+
+_:has_Makeup a owl:Restriction ;
+    owl:hasValue tag:Makeup ;
+    owl:onProperty brick:hasTag .
+
+_:has_Massage a owl:Restriction ;
+    owl:hasValue tag:Massage ;
+    owl:onProperty brick:hasTag .
+
+_:has_Mechanical a owl:Restriction ;
+    owl:hasValue tag:Mechanical ;
+    owl:onProperty brick:hasTag .
+
+_:has_NVR a owl:Restriction ;
+    owl:hasValue tag:NVR ;
+    owl:onProperty brick:hasTag .
+
+_:has_Oil a owl:Restriction ;
+    owl:hasValue tag:Oil ;
+    owl:onProperty brick:hasTag .
+
+_:has_Open a owl:Restriction ;
+    owl:hasValue tag:Open ;
+    owl:onProperty brick:hasTag .
+
+_:has_Operating a owl:Restriction ;
+    owl:hasValue tag:Operating ;
+    owl:onProperty brick:hasTag .
+
+_:has_Override a owl:Restriction ;
+    owl:hasValue tag:Override ;
+    owl:onProperty brick:hasTag .
+
+_:has_PM1 a owl:Restriction ;
+    owl:hasValue tag:PM1 ;
+    owl:onProperty brick:hasTag .
+
+_:has_PM10 a owl:Restriction ;
+    owl:hasValue tag:PM10 ;
+    owl:onProperty brick:hasTag .
+
+_:has_PM2.5 a owl:Restriction ;
+    owl:hasValue tag:PM2.5 ;
+    owl:onProperty brick:hasTag .
+
+_:has_Pre a owl:Restriction ;
+    owl:hasValue tag:Pre ;
+    owl:onProperty brick:hasTag .
+
+_:has_Rain a owl:Restriction ;
+    owl:hasValue tag:Rain ;
+    owl:onProperty brick:hasTag .
+
+_:has_Riser a owl:Restriction ;
+    owl:hasValue tag:Riser ;
+    owl:onProperty brick:hasTag .
+
+_:has_Rooftop a owl:Restriction ;
+    owl:hasValue tag:Rooftop ;
+    owl:onProperty brick:hasTag .
+
+_:has_Shade a owl:Restriction ;
+    owl:hasValue tag:Shade ;
+    owl:onProperty brick:hasTag .
+
+_:has_Shower a owl:Restriction ;
+    owl:hasValue tag:Shower ;
+    owl:onProperty brick:hasTag .
+
+_:has_TVOC a owl:Restriction ;
+    owl:hasValue tag:TVOC ;
+    owl:onProperty brick:hasTag .
+
+_:has_Tank a owl:Restriction ;
+    owl:hasValue tag:Tank ;
+    owl:onProperty brick:hasTag .
+
+_:has_Torque a owl:Restriction ;
+    owl:hasValue tag:Torque ;
+    owl:onProperty brick:hasTag .
+
+_:has_Tower a owl:Restriction ;
+    owl:hasValue tag:Tower ;
+    owl:onProperty brick:hasTag .
+
+_:has_Transformer a owl:Restriction ;
+    owl:hasValue tag:Transformer ;
+    owl:onProperty brick:hasTag .
+
+_:has_Ventilation a owl:Restriction ;
+    owl:hasValue tag:Ventilation ;
+    owl:onProperty brick:hasTag .
+
+_:has_Wet a owl:Restriction ;
+    owl:hasValue tag:Wet ;
+    owl:onProperty brick:hasTag .
+
+_:has_Wheel a owl:Restriction ;
+    owl:hasValue tag:Wheel ;
+    owl:onProperty brick:hasTag .
+
+_:has_Wind a owl:Restriction ;
+    owl:hasValue tag:Wind ;
+    owl:onProperty brick:hasTag .
+
+_:has_Angle a owl:Restriction ;
+    owl:hasValue tag:Angle ;
+    owl:onProperty brick:hasTag .
+
+_:has_Battery a owl:Restriction ;
+    owl:hasValue tag:Battery ;
+    owl:onProperty brick:hasTag .
+
+_:has_Chiller a owl:Restriction ;
+    owl:hasValue tag:Chiller ;
+    owl:onProperty brick:hasTag .
+
+_:has_Elevator a owl:Restriction ;
+    owl:hasValue tag:Elevator ;
+    owl:onProperty brick:hasTag .
+
+_:has_Entering a owl:Restriction ;
+    owl:hasValue tag:Entering ;
+    owl:onProperty brick:hasTag .
+
+_:has_Frame a owl:Restriction ;
+    owl:hasValue tag:Frame ;
+    owl:onProperty brick:hasTag .
+
+_:has_Frequency a owl:Restriction ;
+    owl:hasValue tag:Frequency ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fresh a owl:Restriction ;
+    owl:hasValue tag:Fresh ;
+    owl:onProperty brick:hasTag .
+
+_:has_Generator a owl:Restriction ;
+    owl:hasValue tag:Generator ;
+    owl:onProperty brick:hasTag .
+
+_:has_Grains a owl:Restriction ;
+    owl:hasValue tag:Grains ;
+    owl:onProperty brick:hasTag .
+
+_:has_HVAC a owl:Restriction ;
+    owl:hasValue tag:HVAC ;
+    owl:onProperty brick:hasTag .
+
+_:has_Heater a owl:Restriction ;
+    owl:hasValue tag:Heater ;
+    owl:onProperty brick:hasTag .
+
+_:has_Intercom a owl:Restriction ;
+    owl:hasValue tag:Intercom ;
+    owl:onProperty brick:hasTag .
+
+_:has_Lead a owl:Restriction ;
+    owl:hasValue tag:Lead ;
+    owl:onProperty brick:hasTag .
+
+_:has_Leak a owl:Restriction ;
+    owl:hasValue tag:Leak ;
+    owl:onProperty brick:hasTag .
+
+_:has_Lighting a owl:Restriction ;
+    owl:hasValue tag:Lighting ;
+    owl:onProperty brick:hasTag .
+
+_:has_Lobby a owl:Restriction ;
+    owl:hasValue tag:Lobby ;
+    owl:onProperty brick:hasTag .
+
+_:has_Overridden a owl:Restriction ;
+    owl:hasValue tag:Overridden ;
+    owl:onProperty brick:hasTag .
+
+_:has_Parking a owl:Restriction ;
+    owl:hasValue tag:Parking ;
+    owl:onProperty brick:hasTag .
+
+_:has_Reheat a owl:Restriction ;
+    owl:hasValue tag:Reheat ;
+    owl:onProperty brick:hasTag .
+
+_:has_Smoke a owl:Restriction ;
+    owl:hasValue tag:Smoke ;
+    owl:onProperty brick:hasTag .
+
+_:has_Surveillance a owl:Restriction ;
+    owl:hasValue tag:Surveillance ;
+    owl:onProperty brick:hasTag .
+
+_:has_Thermal a owl:Restriction ;
+    owl:hasValue tag:Thermal ;
+    owl:onProperty brick:hasTag .
+
+_:has_Tolerance a owl:Restriction ;
+    owl:hasValue tag:Tolerance ;
+    owl:onProperty brick:hasTag .
+
+_:has_Variable a owl:Restriction ;
+    owl:hasValue tag:Variable ;
+    owl:onProperty brick:hasTag .
+
+_:has_Volume a owl:Restriction ;
+    owl:hasValue tag:Volume ;
+    owl:onProperty brick:hasTag .
+
+_:has_Area a owl:Restriction ;
+    owl:hasValue tag:Area ;
+    owl:onProperty brick:hasTag .
+
+_:has_Baseboard a owl:Restriction ;
+    owl:hasValue tag:Baseboard ;
+    owl:onProperty brick:hasTag .
+
+_:has_Control a owl:Restriction ;
+    owl:hasValue tag:Control ;
+    owl:onProperty brick:hasTag .
+
+_:has_Enclosed a owl:Restriction ;
+    owl:hasValue tag:Enclosed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fault a owl:Restriction ;
+    owl:hasValue tag:Fault ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fixed a owl:Restriction ;
+    owl:hasValue tag:Fixed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Floor a owl:Restriction ;
+    owl:hasValue tag:Floor ;
+    owl:onProperty brick:hasTag .
+
+_:has_Interface a owl:Restriction ;
+    owl:hasValue tag:Interface ;
+    owl:onProperty brick:hasTag .
+
+_:has_Leaving a owl:Restriction ;
+    owl:hasValue tag:Leaving ;
+    owl:onProperty brick:hasTag .
+
+_:has_Loss a owl:Restriction ;
+    owl:hasValue tag:Loss ;
+    owl:onProperty brick:hasTag .
+
+_:has_Luminance a owl:Restriction ;
+    owl:hasValue tag:Luminance ;
+    owl:onProperty brick:hasTag .
+
+_:has_Media a owl:Restriction ;
+    owl:hasValue tag:Media ;
+    owl:onProperty brick:hasTag .
+
+_:has_Occupancy a owl:Restriction ;
+    owl:hasValue tag:Occupancy ;
+    owl:onProperty brick:hasTag .
+
+_:has_Outdoor a owl:Restriction ;
+    owl:hasValue tag:Outdoor ;
+    owl:onProperty brick:hasTag .
+
+_:has_Run a owl:Restriction ;
+    owl:hasValue tag:Run ;
+    owl:onProperty brick:hasTag .
+
+_:has_Solar a owl:Restriction ;
+    owl:hasValue tag:Solar ;
+    owl:onProperty brick:hasTag .
+
+_:has_Solid a owl:Restriction ;
+    owl:hasValue tag:Solid ;
+    owl:onProperty brick:hasTag .
+
+_:has_Switch a owl:Restriction ;
+    owl:hasValue tag:Switch ;
+    owl:onProperty brick:hasTag .
+
+_:has_Voltage a owl:Restriction ;
+    owl:hasValue tag:Voltage ;
+    owl:onProperty brick:hasTag .
+
+_:has_Wash a owl:Restriction ;
+    owl:hasValue tag:Wash ;
+    owl:onProperty brick:hasTag .
+
+_:has_Basin a owl:Restriction ;
+    owl:hasValue tag:Basin ;
+    owl:onProperty brick:hasTag .
+
+_:has_Collection a owl:Restriction ;
+    owl:hasValue tag:Collection ;
+    owl:onProperty brick:hasTag .
+
+_:has_Detection a owl:Restriction ;
+    owl:hasValue tag:Detection ;
+    owl:onProperty brick:hasTag .
+
+_:has_Direction a owl:Restriction ;
+    owl:hasValue tag:Direction ;
+    owl:onProperty brick:hasTag .
+
+_:has_Energy a owl:Restriction ;
+    owl:hasValue tag:Energy ;
+    owl:onProperty brick:hasTag .
+
+_:has_Exchanger a owl:Restriction ;
+    owl:hasValue tag:Exchanger ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fire a owl:Restriction ;
+    owl:hasValue tag:Fire ;
+    owl:onProperty brick:hasTag .
+
+_:has_Laboratory a owl:Restriction ;
+    owl:hasValue tag:Laboratory ;
+    owl:onProperty brick:hasTag .
+
+_:has_Lockout a owl:Restriction ;
+    owl:hasValue tag:Lockout ;
+    owl:onProperty brick:hasTag .
+
+_:has_Output a owl:Restriction ;
+    owl:hasValue tag:Output ;
+    owl:onProperty brick:hasTag .
+
+_:has_Preheat a owl:Restriction ;
+    owl:hasValue tag:Preheat ;
+    owl:onProperty brick:hasTag .
+
+_:has_Stack a owl:Restriction ;
+    owl:hasValue tag:Stack ;
+    owl:onProperty brick:hasTag .
+
+_:has_Station a owl:Restriction ;
+    owl:hasValue tag:Station ;
+    owl:onProperty brick:hasTag .
+
+_:has_Storage a owl:Restriction ;
+    owl:hasValue tag:Storage ;
+    owl:onProperty brick:hasTag .
+
+_:has_Usage a owl:Restriction ;
+    owl:hasValue tag:Usage ;
+    owl:onProperty brick:hasTag .
+
+_:has_VFD a owl:Restriction ;
+    owl:hasValue tag:VFD ;
+    owl:onProperty brick:hasTag .
+
+_:has_Velocity a owl:Restriction ;
+    owl:hasValue tag:Velocity ;
+    owl:onProperty brick:hasTag .
+
+_:has_Vertical a owl:Restriction ;
+    owl:hasValue tag:Vertical ;
+    owl:onProperty brick:hasTag .
+
+_:has_Video a owl:Restriction ;
+    owl:hasValue tag:Video ;
+    owl:onProperty brick:hasTag .
+
+_:has_Average a owl:Restriction ;
+    owl:hasValue tag:Average ;
+    owl:onProperty brick:hasTag .
+
+_:has_CO a owl:Restriction ;
+    owl:hasValue tag:CO ;
+    owl:onProperty brick:hasTag .
+
+_:has_Coil a owl:Restriction ;
+    owl:hasValue tag:Coil ;
+    owl:onProperty brick:hasTag .
+
+_:has_Distribution a owl:Restriction ;
+    owl:hasValue tag:Distribution ;
+    owl:onProperty brick:hasTag .
+
+_:has_Gain a owl:Restriction ;
+    owl:hasValue tag:Gain ;
+    owl:onProperty brick:hasTag .
+
+_:has_Motor a owl:Restriction ;
+    owl:hasValue tag:Motor ;
+    owl:onProperty brick:hasTag .
+
+_:has_Standby a owl:Restriction ;
+    owl:hasValue tag:Standby ;
+    owl:onProperty brick:hasTag .
+
+_:has_Bypass a owl:Restriction ;
+    owl:hasValue tag:Bypass ;
+    owl:onProperty brick:hasTag .
+
+_:has_Current a owl:Restriction ;
+    owl:hasValue tag:Current ;
+    owl:onProperty brick:hasTag .
+
+_:has_Dewpoint a owl:Restriction ;
+    owl:hasValue tag:Dewpoint ;
+    owl:onProperty brick:hasTag .
+
+_:has_Domestic a owl:Restriction ;
+    owl:hasValue tag:Domestic ;
+    owl:onProperty brick:hasTag .
+
+_:has_Mixed a owl:Restriction ;
+    owl:hasValue tag:Mixed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Start a owl:Restriction ;
+    owl:hasValue tag:Start ;
+    owl:onProperty brick:hasTag .
+
+_:has_Stop a owl:Restriction ;
+    owl:hasValue tag:Stop ;
+    owl:onProperty brick:hasTag .
+
+_:has_Telecom a owl:Restriction ;
+    owl:hasValue tag:Telecom ;
+    owl:onProperty brick:hasTag .
+
+_:has_Unit a owl:Restriction ;
+    owl:hasValue tag:Unit ;
+    owl:onProperty brick:hasTag .
+
+_:has_Box a owl:Restriction ;
+    owl:hasValue tag:Box ;
+    owl:onProperty brick:hasTag .
+
+_:has_Disable a owl:Restriction ;
+    owl:hasValue tag:Disable ;
+    owl:onProperty brick:hasTag .
+
+_:has_Effective a owl:Restriction ;
+    owl:hasValue tag:Effective ;
+    owl:onProperty brick:hasTag .
+
+_:has_Mode a owl:Restriction ;
+    owl:hasValue tag:Mode ;
+    owl:onProperty brick:hasTag .
+
+_:has_Office a owl:Restriction ;
+    owl:hasValue tag:Office ;
+    owl:onProperty brick:hasTag .
+
+_:has_Radiator a owl:Restriction ;
+    owl:hasValue tag:Radiator ;
+    owl:onProperty brick:hasTag .
+
+_:has_Relative a owl:Restriction ;
+    owl:hasValue tag:Relative ;
+    owl:onProperty brick:hasTag .
+
+_:has_Steam a owl:Restriction ;
+    owl:hasValue tag:Steam ;
+    owl:onProperty brick:hasTag .
+
+_:has_Common a owl:Restriction ;
+    owl:hasValue tag:Common ;
+    owl:onProperty brick:hasTag .
+
+_:has_Enthalpy a owl:Restriction ;
+    owl:hasValue tag:Enthalpy ;
+    owl:onProperty brick:hasTag .
+
+_:has_Damper a owl:Restriction ;
+    owl:hasValue tag:Damper ;
+    owl:onProperty brick:hasTag .
+
+_:has_Matter a owl:Restriction ;
+    owl:hasValue tag:Matter ;
+    owl:onProperty brick:hasTag .
+
+_:has_Particulate a owl:Restriction ;
+    owl:hasValue tag:Particulate ;
+    owl:onProperty brick:hasTag .
+
+_:has_Position a owl:Restriction ;
+    owl:hasValue tag:Position ;
+    owl:onProperty brick:hasTag .
+
+_:has_Pump a owl:Restriction ;
+    owl:hasValue tag:Pump ;
+    owl:onProperty brick:hasTag .
+
+_:has_Step a owl:Restriction ;
+    owl:hasValue tag:Step ;
+    owl:onProperty brick:hasTag .
+
+_:has_CO2 a owl:Restriction ;
+    owl:hasValue tag:CO2 ;
+    owl:onProperty brick:hasTag .
+
+_:has_Filter a owl:Restriction ;
+    owl:hasValue tag:Filter ;
+    owl:onProperty brick:hasTag .
+
+_:has_Building a owl:Restriction ;
+    owl:hasValue tag:Building ;
+    owl:onProperty brick:hasTag .
+
+_:has_Electrical a owl:Restriction ;
+    owl:hasValue tag:Electrical ;
+    owl:onProperty brick:hasTag .
+
+_:has_Level a owl:Restriction ;
+    owl:hasValue tag:Level ;
+    owl:onProperty brick:hasTag .
+
+_:has_Medium a owl:Restriction ;
+    owl:hasValue tag:Medium ;
+    owl:onProperty brick:hasTag .
+
+_:has_Safety a owl:Restriction ;
+    owl:hasValue tag:Safety ;
+    owl:onProperty brick:hasTag .
+
+_:has_Security a owl:Restriction ;
+    owl:hasValue tag:Security ;
+    owl:onProperty brick:hasTag .
+
+_:has_Service a owl:Restriction ;
+    owl:hasValue tag:Service ;
+    owl:onProperty brick:hasTag .
+
+_:has_Speed a owl:Restriction ;
+    owl:hasValue tag:Speed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Demand a owl:Restriction ;
+    owl:hasValue tag:Demand ;
+    owl:onProperty brick:hasTag .
+
+_:has_Meter a owl:Restriction ;
+    owl:hasValue tag:Meter ;
+    owl:onProperty brick:hasTag .
+
+_:has_Power a owl:Restriction ;
+    owl:hasValue tag:Power ;
+    owl:onProperty brick:hasTag .
+
+_:has_Emergency a owl:Restriction ;
+    owl:hasValue tag:Emergency ;
+    owl:onProperty brick:hasTag .
+
+_:has_On a owl:Restriction ;
+    owl:hasValue tag:On ;
+    owl:onProperty brick:hasTag .
+
+_:has_Condenser a owl:Restriction ;
+    owl:hasValue tag:Condenser ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fan a owl:Restriction ;
+    owl:hasValue tag:Fan ;
+    owl:onProperty brick:hasTag .
+
+_:has_Off a owl:Restriction ;
+    owl:hasValue tag:Off ;
+    owl:onProperty brick:hasTag .
+
+_:has_Enable a owl:Restriction ;
+    owl:hasValue tag:Enable ;
+    owl:onProperty brick:hasTag .
+
+_:has_Integral a owl:Restriction ;
+    owl:hasValue tag:Integral ;
+    owl:onProperty brick:hasTag .
+
+_:has_Low a owl:Restriction ;
+    owl:hasValue tag:Low ;
+    owl:onProperty brick:hasTag .
+
+_:has_Unoccupied a owl:Restriction ;
+    owl:hasValue tag:Unoccupied ;
+    owl:onProperty brick:hasTag .
+
+_:has_Band a owl:Restriction ;
+    owl:hasValue tag:Band ;
+    owl:onProperty brick:hasTag .
+
+_:has_Gas a owl:Restriction ;
+    owl:hasValue tag:Gas ;
+    owl:onProperty brick:hasTag .
+
+_:has_Shed a owl:Restriction ;
+    owl:hasValue tag:Shed ;
+    owl:onProperty brick:hasTag .
+
+_:has_Zone a owl:Restriction ;
+    owl:hasValue tag:Zone ;
+    owl:onProperty brick:hasTag .
+
+_:has_Deadband a owl:Restriction ;
+    owl:hasValue tag:Deadband ;
+    owl:onProperty brick:hasTag .
+
+_:has_High a owl:Restriction ;
+    owl:hasValue tag:High ;
+    owl:onProperty brick:hasTag .
+
+_:has_Proportional a owl:Restriction ;
+    owl:hasValue tag:Proportional ;
+    owl:onProperty brick:hasTag .
+
+_:has_Valve a owl:Restriction ;
+    owl:hasValue tag:Valve ;
+    owl:onProperty brick:hasTag .
+
+_:has_Occupied a owl:Restriction ;
+    owl:hasValue tag:Occupied ;
+    owl:onProperty brick:hasTag .
+
+_:has_Time a owl:Restriction ;
+    owl:hasValue tag:Time ;
+    owl:onProperty brick:hasTag .
+
+_:has_Exhaust a owl:Restriction ;
+    owl:hasValue tag:Exhaust ;
+    owl:onProperty brick:hasTag .
+
+_:has_Load a owl:Restriction ;
+    owl:hasValue tag:Load ;
+    owl:onProperty brick:hasTag .
+
+_:has_Humidity a owl:Restriction ;
+    owl:hasValue tag:Humidity ;
+    owl:onProperty brick:hasTag .
+
+_:has_Max a owl:Restriction ;
+    owl:hasValue tag:Max ;
+    owl:onProperty brick:hasTag .
+
+_:has_Min a owl:Restriction ;
+    owl:hasValue tag:Min ;
+    owl:onProperty brick:hasTag .
+
+_:has_Chilled a owl:Restriction ;
+    owl:hasValue tag:Chilled ;
+    owl:onProperty brick:hasTag .
+
+_:has_Liquid a owl:Restriction ;
+    owl:hasValue tag:Liquid ;
+    owl:onProperty brick:hasTag .
+
+_:has_Outside a owl:Restriction ;
+    owl:hasValue tag:Outside ;
+    owl:onProperty brick:hasTag .
+
+_:has_Reset a owl:Restriction ;
+    owl:hasValue tag:Reset ;
+    owl:onProperty brick:hasTag .
+
+_:has_Static a owl:Restriction ;
+    owl:hasValue tag:Static ;
+    owl:onProperty brick:hasTag .
+
+_:has_Cool a owl:Restriction ;
+    owl:hasValue tag:Cool ;
+    owl:onProperty brick:hasTag .
+
+_:has_Return a owl:Restriction ;
+    owl:hasValue tag:Return ;
+    owl:onProperty brick:hasTag .
+
+_:has_System a owl:Restriction ;
+    owl:hasValue tag:System ;
+    owl:onProperty brick:hasTag .
+
+_:has_Fluid a owl:Restriction ;
+    owl:hasValue tag:Fluid ;
+    owl:onProperty brick:hasTag .
+
+_:has_PID a owl:Restriction ;
+    owl:hasValue tag:PID ;
+    owl:onProperty brick:hasTag .
+
+_:has_Alarm a owl:Restriction ;
+    owl:hasValue tag:Alarm ;
+    owl:onProperty brick:hasTag .
+
+_:has_Command a owl:Restriction ;
+    owl:hasValue tag:Command ;
+    owl:onProperty brick:hasTag .
+
+_:has_Hot a owl:Restriction ;
+    owl:hasValue tag:Hot ;
+    owl:onProperty brick:hasTag .
+
+_:has_Limit a owl:Restriction ;
+    owl:hasValue tag:Limit ;
+    owl:onProperty brick:hasTag .
+
+_:has_Differential a owl:Restriction ;
+    owl:hasValue tag:Differential ;
+    owl:onProperty brick:hasTag .
+
+_:has_Heat a owl:Restriction ;
+    owl:hasValue tag:Heat ;
+    owl:onProperty brick:hasTag .
+
+_:has_Status a owl:Restriction ;
+    owl:hasValue tag:Status ;
+    owl:onProperty brick:hasTag .
+
+_:has_Room a owl:Restriction ;
+    owl:hasValue tag:Room ;
+    owl:onProperty brick:hasTag .
+
+_:has_Discharge a owl:Restriction ;
+    owl:hasValue tag:Discharge ;
+    owl:onProperty brick:hasTag .
+
+_:has_Space a owl:Restriction ;
+    owl:hasValue tag:Space ;
+    owl:onProperty brick:hasTag .
+
+_:has_Flow a owl:Restriction ;
+    owl:hasValue tag:Flow ;
+    owl:onProperty brick:hasTag .
+
+_:has_Supply a owl:Restriction ;
+    owl:hasValue tag:Supply ;
+    owl:onProperty brick:hasTag .
+
+_:has_Pressure a owl:Restriction ;
+    owl:hasValue tag:Pressure ;
+    owl:onProperty brick:hasTag .
+
+_:has_Location a owl:Restriction ;
+    owl:hasValue tag:Location ;
+    owl:onProperty brick:hasTag .
+
+_:has_Parameter a owl:Restriction ;
+    owl:hasValue tag:Parameter ;
+    owl:onProperty brick:hasTag .
+
+_:has_Equipment a owl:Restriction ;
+    owl:hasValue tag:Equipment ;
+    owl:onProperty brick:hasTag .
+
+_:has_Water a owl:Restriction ;
+    owl:hasValue tag:Water ;
+    owl:onProperty brick:hasTag .
+
+_:has_Temperature a owl:Restriction ;
+    owl:hasValue tag:Temperature ;
+    owl:onProperty brick:hasTag .
+
+_:has_Sensor a owl:Restriction ;
+    owl:hasValue tag:Sensor ;
+    owl:onProperty brick:hasTag .
+
+_:has_Setpoint a owl:Restriction ;
+    owl:hasValue tag:Setpoint ;
+    owl:onProperty brick:hasTag .
+
+_:has_Air a owl:Restriction ;
+    owl:hasValue tag:Air ;
+    owl:onProperty brick:hasTag .
+
+_:has_Point a owl:Restriction ;
+    owl:hasValue tag:Point ;
+    owl:onProperty brick:hasTag .


### PR DESCRIPTION
Closes #16. See https://brickschema.org/ontology/1.2. Note that the ontology now includes *Shapes such as https://brickschema.org/ontology/1.2/classes/AggregationShape etc., which may affect the singular `BSH_1_2` namespace.